### PR TITLE
Error parsing HTTP header with an empty value

### DIFF
--- a/muduo/net/http/HttpRequest.h
+++ b/muduo/net/http/HttpRequest.h
@@ -128,7 +128,7 @@ class HttpRequest : public muduo::copyable
   {
     string field(start, colon);
     ++colon;
-    while (isspace(*colon))
+    while (isspace(*colon) && colon < end)
     {
       ++colon;
     }


### PR DESCRIPTION
**Sending a HTTP request to muduo::net::HttpServer.cc(using the httpserver_test) will result in crashing of httpserver_test.**

Testcase in which the `User-Agent` field has an empty value:
"GET /hello HTTP/1.1\r\nHost:localhost\r\nUser-Agent:\r\nAccept-Encoding: gzip,deflate,sdch\r\nAccept-Language: en-us,fr\r\nAccept-Charset: iso-8859-1,_,utf-8\r\n\r\n"
<br/><br/>
*_The backtrace of gdb is as following:**
terminate called after throwing an instance of 'std::length_error'
  what():  basic_string::_S_create

Program received signal SIGABRT, Aborted.
#6  0x00007ffff770d307 in std::__throw_length_error(char const*) () from /usr/lib/libstdc++.so.6
#7  0x00007ffff774eb42 in std::string::_Rep::_S_create(unsigned long, unsigned long, std::allocator<char> const&) () from /usr/lib/libstdc++.so.6
#8  0x000000000045a6fb in std::string::_S_construct<char const*> (__beg=0x6a8ac2 "Accept-Encoding: gzip,deflate,sdch\r\nAccept-Language: en-us,fr\r\nAccept-Charset: iso-8859-1,_,utf-8\r\n\r\n",__end=0x6a8ac0 "\r\nAccept-Encoding: gzip,deflate,sdch\r\nAccept-Language: en-us,fr\r\nAccept-Charset: iso-8859-1,_,utf-8\r\n\r\n",__a=...) at /usr/include/c++/4.4/bits/basic_string.tcc:139
#9  0x00000000004599d7 in std::string::_S_construct_aux<char const*> (__beg=0x6a8ac2 "Accept-Encoding: gzip,deflate,sdch\r\nAccept-Language: en-us,fr\r\nAccept-Charset: iso-8859-1,_,utf-8\r\n\r\n",__end=0x6a8ac0 "\r\nAccept-Encoding: gzip,deflate,sdch\r\nAccept-Language: en-us,fr\r\nAccept-Charset: iso-8859-1,_,utf-8\r\n\r\n",__a=...) at /usr/include/c++/4.4/bits/basic_string.h:1543
#10 0x00000000004586ba in std::string::_S_construct<char const*> (__beg=0x6a8ac2 "Accept-Encoding: gzip,deflate,sdch\r\nAccept-Language: en-us,fr\r\nAccept-Charset: iso-8859-1,_,utf-8\r\n\r\n",__end=0x6a8ac0 "\r\nAccept-Encoding: gzip,deflate,sdch\r\nAccept-Language: en-us,fr\r\nAccept-Charset: iso-8859-1,_,utf-8\r\n\r\n",__a=...) at /usr/include/c++/4.4/bits/basic_string.h:1559
#11 0x00000000004579f7 in basic_string<char const*> (this=0x7fffffffa360,__beg=0x6a8ac2 "Accept-Encoding: gzip,deflate,sdch\r\nAccept-Language: en-us,fr\r\nAccept-Charset: iso-8859-1,_,utf-8\r\n\r\n",__end=0x6a8ac0 "\r\nAccept-Encoding: gzip,deflate,sdch\r\nAccept-Language: en-us,fr\r\nAccept-Charset: iso-8859-1,_,utf-8\r\n\r\n",__a=...) at /usr/include/c++/4.4/bits/basic_string.tcc:230
#12 0x0000000000456e12 in muduo::net::HttpRequest::addHeader (this=0x6a93b0,start=0x6a8ab5 "User-Agent:\r\nAccept-Encoding: gzip,deflate,sdch\r\nAccept-Language: en-us,fr\r\nAccept-Charset: iso-8859-1,_,utf-8\r\n\r\n",colon=0x6a8ac2 "Accept-Encoding: gzip,deflate,sdch\r\nAccept-Language: en-us,fr\r\nAccept-Charset: iso-8859-1,_,utf-8\r\n\r\n",end=0x6a8ac0 "\r\nAccept-Encoding: gzip,deflate,sdch\r\nAccept-Language: en-us,fr\r\nAccept-Charset: iso-8859-1,_,utf-8\r\n\r\n") at /_******/muduo/net/http/HttpRequest.h:135
#13 0x000000000045536e in parseRequest (buf=0x6a8a00, context=0x6a93a8, receiveTime=...) at /*******/muduo/net/http/HttpServer.cc:96
#14 0x0000000000455c95 in muduo::net::HttpServer::onMessage (this=0x7fffffffe880, conn=..., buf=0x6a8a00, receiveTime=...) at /*******/muduo/net/http/HttpServer.cc:165

<br/><br/>

**According to the [protocol of HTTP](http://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2), the 'field-value' of a HTTP header may be an empty string.**
At /muduo/net/http/HttpRequest.h:131 , the pointer `colon` is not supposed to pass the pointer`end`.
