### PR TITLE
POC of using premake to compile muduo: use base, net, and simple_echo as examples

### DIFF
--- a/examples/simple/premake4.lua
+++ b/examples/simple/premake4.lua
@@ -1,0 +1,10 @@
+project "simple_echo"
+    kind "ConsoleApp"
+    language "C++"
+    targetdir(bindir)
+    links{'net', 'base', 'pthread', 'rt'}
+    files {
+        'echo/echo.cc',
+        'echo/main.cc',
+    }
+

--- a/muduo/base/premake4.lua
+++ b/muduo/base/premake4.lua
@@ -1,0 +1,24 @@
+project "base"
+    kind "StaticLib"
+    language "C++"
+    links{'pthread', 'rt'}
+    targetdir(libdir)
+    targetname('muduo_base')
+    headersdir('muduo/base')
+    headers('*.h')
+    files {
+            'AsyncLogging.cc',
+            'Condition.cc',
+            'CountDownLatch.cc',
+            'Date.cc',
+            'Exception.cc',
+            'FileUtil.cc',
+            'LogFile.cc',
+            'Logging.cc',
+            'LogStream.cc',
+            'ProcessInfo.cc',
+            'Timestamp.cc',
+            'TimeZone.cc',
+            'Thread.cc',
+            'ThreadPool.cc',
+     }

--- a/muduo/net/premake4.lua
+++ b/muduo/net/premake4.lua
@@ -1,0 +1,45 @@
+project "net"
+    kind "StaticLib"
+    language "C++"
+    links('base')
+    targetdir(libdir)
+    targetname('muduo_net')
+    includedirs('../..')
+    headersdir('muduo/net')
+    headers {
+        'Buffer.h',
+        'Callbacks.h',
+        'Channel.h',
+        'Endian.h',
+        'EventLoop.h',
+        'EventLoopThread.h',
+        'EventLoopThreadPool.h',
+        'InetAddress.h',
+        'TcpClient.h',
+        'TcpConnection.h',
+        'TcpServer.h',
+        'TimerId.h',
+    }
+
+    files {
+        'Acceptor.cc',
+        'Buffer.cc',
+        'Channel.cc',
+        'Connector.cc',
+        'EventLoop.cc',
+        'EventLoopThread.cc',
+        'EventLoopThreadPool.cc',
+        'InetAddress.cc',
+        'Poller.cc',
+        'poller/DefaultPoller.cc',
+        'poller/EPollPoller.cc',
+        'poller/PollPoller.cc',
+        'Socket.cc',
+        'SocketsOps.cc',
+        'TcpClient.cc',
+        'TcpConnection.cc',
+        'TcpServer.cc',
+        'Timer.cc',
+        'TimerQueue.cc',
+     }
+

--- a/premake4.lua
+++ b/premake4.lua
@@ -1,0 +1,69 @@
+solution "muduo"
+    projectdir = basedir()
+    builddir = path.join(projectdir, '../build')
+    installdir = path.join(projectdir, '../install')
+    bindir = path.join(installdir, 'bin')
+    libdir = path.join(installdir, 'lib')
+    includedir = path.join(installdir, 'include')
+    curheadersdir = includedir
+
+    -- set the sub header dir to install files
+    function headersdir(dir)
+        curheadersdir = dir
+    end
+
+    -- install header files
+    function headers(files)
+        if type(files) == 'string' then
+            files = { files }
+        end
+        local finalfiles = {}
+        for _, file in ipairs(files) do
+            if file:find('*') then
+                file = os.matchfiles(file)
+            end 
+            finalfiles = table.join(finalfiles, file)
+        end
+        local source = table.concat(finalfiles, ' ')
+        local target = path.join(includedir, curheadersdir)
+        assert(os.mkdir(target))
+        assert(os.execute('cp ' .. source .. ' ' .. target))
+    end
+
+    -- solution level settings
+    configurations { "Debug", "Release" }
+    location(builddir)
+    includedirs(includedir)
+
+    defines '_FILE_OFFSET_BITS=64'
+    flags {"ExtraWarnings", "FatalWarnings"}
+    buildoptions { '-g', 
+                   '-march=native', 
+                   '-rdynamic',
+                   '-Wconversion',
+                   '-Wno-unused-parameter',
+                   '-Wold-style-cast',
+                   '-Woverloaded-virtual',
+                   '-Wpointer-arith',
+                   '-Wshadow',
+                   '-Wwrite-strings',
+    } 
+
+    configuration "Debug"
+        buildoptions {'-O0'} 
+        targetsuffix('-g')
+    configuration "Release"
+        buildoptions {'-finline-limit=1000'}
+        defines { "NDEBUG" }
+        flags { "Optimize" }  
+
+--   filter by kind not support in premake4.4 .4 .4 .4 beta
+--    configuration {"*App"}
+--        targetdir(bindir)
+--    configuration { "*Lib" }
+--        targetdir(libdir)
+--    configuration {}
+
+    include 'muduo/base'
+    include 'muduo/net'
+    include 'examples/simple'


### PR DESCRIPTION
Premake is a meta build system similar to cmake, although not as mature as cmake, premake is more flexible by leveraging _lua_ as its build script format, compared to cmake:
- It provides a better structured domain model: solution - project - configuration
- it is more flexible - it is easier to twist for corner cases, and extend it yourself when you need more power, write build script is also programming

Here are a few links:
- [User Guide](http://industriousone.com/premake/userguide)
- [BitBucket Repo](https://bitbucket.org/premake/premake-stable)

For this change in specific, it is obvious not a full support to use premake to build muduo, but rather a POC - which proves use premake to build muduo is feasible, and also quite elegant:)

To try with it:
1. Install [premake4.4 beta](http://industriousone.com/premake/download)
2. Run _premake gmake_ to generate make file
3. Run _make -C ../build/ config=release_ to build
4. See what has generated:

```
$ tree ../install
../install
├── bin
│   └── simple_echo
├── include
│   └── muduo
│       ├── base
│       │   ├── AsyncLogging.h
│       │   ├── Atomic.h
│       │   ├── BlockingQueue.h
│       │   ├── BoundedBlockingQueue.h
│       │   ├── Condition.h
│       │   ├── copyable.h
│       │   ├── CountDownLatch.h
│       │   ├── CurrentThread.h
│       │   ├── Date.h
│       │   ├── Exception.h
│       │   ├── FileUtil.h
│       │   ├── LogFile.h
│       │   ├── Logging.h
│       │   ├── LogStream.h
│       │   ├── Mutex.h
│       │   ├── ProcessInfo.h
│       │   ├── Singleton.h
│       │   ├── StringPiece.h
│       │   ├── Thread.h
│       │   ├── ThreadLocal.h
│       │   ├── ThreadLocalSingleton.h
│       │   ├── ThreadPool.h
│       │   ├── Timestamp.h
│       │   ├── TimeZone.h
│       │   └── Types.h
│       └── net
│           ├── Buffer.h
│           ├── Callbacks.h
│           ├── Channel.h
│           ├── Endian.h
│           ├── EventLoop.h
│           ├── EventLoopThread.h
│           ├── EventLoopThreadPool.h
│           ├── InetAddress.h
│           ├── TcpClient.h
│           ├── TcpConnection.h
│           ├── TcpServer.h
│           └── TimerId.h
└── lib
    ├── libmuduo_base.a
    └── libmuduo_net.a
```

If we agreed, I can work towards to port muduo to build with premake fully.

Thanks.
