### PR TITLE
fix readv and write bug, ignore EINTR and EAGIN

### DIFF
--- a/diff
+++ b/diff
@@ -1,0 +1,40 @@
+diff --git a/muduo/net/TcpConnection.cc b/muduo/net/TcpConnection.cc
+index 28348ee..93722b6 100644
+--- a/muduo/net/TcpConnection.cc
++++ b/muduo/net/TcpConnection.cc
+@@ -159,13 +159,10 @@ void TcpConnection::sendInLoop(const void* data, size_t len)
+     else // nwrote < 0
+     {
+       nwrote = 0;
+-      if (errno != EWOULDBLOCK)
++      if (errno != EAGAIN || errno != EINTR) // FIXME: any others?
+       {
+         LOG_SYSERR << "TcpConnection::sendInLoop";
+-        if (errno == EPIPE) // FIXME: any others?
+-        {
+-          error = true;
+-        }
++        error = true;
+       }
+     }
+   }
+@@ -254,9 +251,16 @@ void TcpConnection::handleRead(Timestamp receiveTime)
+   }
+   else
+   {
+-    errno = savedErrno;
+-    LOG_SYSERR << "TcpConnection::handleRead";
+-    handleError();
++    if (savedErrno == EINTR || savedErrno == EAGAIN) 
++    {
++      messageCallback_(shared_from_this(), &inputBuffer_, receiveTime);
++    }
++    else 
++    {
++      errno = savedErrno;
++      LOG_SYSERR << "TcpConnection::handleRead";
++      handleError();
++    }
+   }
+ }
+ 

--- a/make.sh
+++ b/make.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+cd ../build/debug
+make
+cd -

--- a/muduo/net/TcpConnection.cc
+++ b/muduo/net/TcpConnection.cc
@@ -159,13 +159,10 @@ void TcpConnection::sendInLoop(const void* data, size_t len)
     else // nwrote < 0
     {
       nwrote = 0;
-      if (errno != EWOULDBLOCK)
+      if (errno != EAGAIN || errno != EINTR) // FIXME: any others?
       {
         LOG_SYSERR << "TcpConnection::sendInLoop";
-        if (errno == EPIPE) // FIXME: any others?
-        {
-          error = true;
-        }
+        error = true;
       }
     }
   }
@@ -254,9 +251,16 @@ void TcpConnection::handleRead(Timestamp receiveTime)
   }
   else
   {
-    errno = savedErrno;
-    LOG_SYSERR << "TcpConnection::handleRead";
-    handleError();
+    if (savedErrno == EINTR || savedErrno == EAGAIN) 
+    {
+      messageCallback_(shared_from_this(), &inputBuffer_, receiveTime);
+    }
+    else 
+    {
+      errno = savedErrno;
+      LOG_SYSERR << "TcpConnection::handleRead";
+      handleError();
+    }
   }
 }
 

--- a/tags
+++ b/tags
@@ -1,0 +1,2973 @@
+!_TAG_FILE_FORMAT	2	/extended format; --format=1 will not append ;" to lines/
+!_TAG_FILE_SORTED	1	/0=unsorted, 1=sorted, 2=foldcase/
+!_TAG_PROGRAM_AUTHOR	Darren Hiebert	/dhiebert@users.sourceforge.net/
+!_TAG_PROGRAM_NAME	Exuberant Ctags	//
+!_TAG_PROGRAM_URL	http://ctags.sourceforge.net	/official site/
+!_TAG_PROGRAM_VERSION	5.8	//
+Acceptor	muduo/net/Acceptor.cc	/^Acceptor::Acceptor(EventLoop* loop, const InetAddress& listenAddr, bool reuseport)$/;"	f	class:Acceptor
+Acceptor	muduo/net/Acceptor.h	/^class Acceptor : boost::noncopyable$/;"	c	namespace:muduo::net
+ActiveTimer	muduo/net/TimerQueue.h	/^  typedef std::pair<Timer*, int64_t> ActiveTimer;$/;"	t	class:muduo::net::TimerQueue
+ActiveTimerSet	muduo/net/TimerQueue.h	/^  typedef std::set<ActiveTimer> ActiveTimerSet;$/;"	t	class:muduo::net::TimerQueue
+AnswerPtr	examples/protobuf/codec/client.cc	/^typedef boost::shared_ptr<muduo::Answer> AnswerPtr;$/;"	t	file:
+AnswerPtr	examples/protobuf/codec/dispatcher_test.cc	/^typedef boost::shared_ptr<muduo::Answer> AnswerPtr;$/;"	t	file:
+AnswerPtr	examples/protobuf/codec/server.cc	/^typedef boost::shared_ptr<muduo::Answer> AnswerPtr;$/;"	t	file:
+ArgList	muduo/net/inspect/Inspector.h	/^  typedef std::vector<string> ArgList;$/;"	t	class:muduo::net::Inspector
+AsyncLogging	muduo/base/AsyncLogging.cc	/^AsyncLogging::AsyncLogging(const string& basename,$/;"	f	class:AsyncLogging
+AsyncLogging	muduo/base/AsyncLogging.h	/^class AsyncLogging : boost::noncopyable$/;"	c	namespace:muduo
+AtomicInt32	muduo/base/Atomic.h	/^typedef detail::AtomicIntegerT<int32_t> AtomicInt32;$/;"	t	namespace:muduo
+AtomicInt64	muduo/base/Atomic.h	/^typedef detail::AtomicIntegerT<int64_t> AtomicInt64;$/;"	t	namespace:muduo
+AtomicIntegerT	muduo/base/Atomic.h	/^  AtomicIntegerT()$/;"	f	class:muduo::detail::AtomicIntegerT
+AtomicIntegerT	muduo/base/Atomic.h	/^class AtomicIntegerT : boost::noncopyable$/;"	c	namespace:muduo::detail
+BOOST_AUTO_TEST_CASE	muduo/base/tests/LogStream_test.cc	/^BOOST_AUTO_TEST_CASE(testLogStreamBooleans)$/;"	f
+BOOST_AUTO_TEST_CASE	muduo/base/tests/LogStream_test.cc	/^BOOST_AUTO_TEST_CASE(testLogStreamFloats)$/;"	f
+BOOST_AUTO_TEST_CASE	muduo/base/tests/LogStream_test.cc	/^BOOST_AUTO_TEST_CASE(testLogStreamFmts)$/;"	f
+BOOST_AUTO_TEST_CASE	muduo/base/tests/LogStream_test.cc	/^BOOST_AUTO_TEST_CASE(testLogStreamIntegerLimits)$/;"	f
+BOOST_AUTO_TEST_CASE	muduo/base/tests/LogStream_test.cc	/^BOOST_AUTO_TEST_CASE(testLogStreamIntegers)$/;"	f
+BOOST_AUTO_TEST_CASE	muduo/base/tests/LogStream_test.cc	/^BOOST_AUTO_TEST_CASE(testLogStreamLong)$/;"	f
+BOOST_AUTO_TEST_CASE	muduo/base/tests/LogStream_test.cc	/^BOOST_AUTO_TEST_CASE(testLogStreamStrings)$/;"	f
+BOOST_AUTO_TEST_CASE	muduo/base/tests/LogStream_test.cc	/^BOOST_AUTO_TEST_CASE(testLogStreamVoid)$/;"	f
+BOOST_AUTO_TEST_CASE	muduo/net/http/tests/HttpRequest_unittest.cc	/^BOOST_AUTO_TEST_CASE(testParseRequestAllInOne)$/;"	f
+BOOST_AUTO_TEST_CASE	muduo/net/http/tests/HttpRequest_unittest.cc	/^BOOST_AUTO_TEST_CASE(testParseRequestEmptyHeaderValue)$/;"	f
+BOOST_AUTO_TEST_CASE	muduo/net/http/tests/HttpRequest_unittest.cc	/^BOOST_AUTO_TEST_CASE(testParseRequestInTwoPieces)$/;"	f
+BOOST_AUTO_TEST_CASE	muduo/net/tests/Buffer_unittest.cc	/^BOOST_AUTO_TEST_CASE(testBufferAppendRetrieve)$/;"	f
+BOOST_AUTO_TEST_CASE	muduo/net/tests/Buffer_unittest.cc	/^BOOST_AUTO_TEST_CASE(testBufferGrow)$/;"	f
+BOOST_AUTO_TEST_CASE	muduo/net/tests/Buffer_unittest.cc	/^BOOST_AUTO_TEST_CASE(testBufferInsideGrow)$/;"	f
+BOOST_AUTO_TEST_CASE	muduo/net/tests/Buffer_unittest.cc	/^BOOST_AUTO_TEST_CASE(testBufferPrepend)$/;"	f
+BOOST_AUTO_TEST_CASE	muduo/net/tests/Buffer_unittest.cc	/^BOOST_AUTO_TEST_CASE(testBufferReadInt)$/;"	f
+BOOST_AUTO_TEST_CASE	muduo/net/tests/Buffer_unittest.cc	/^BOOST_AUTO_TEST_CASE(testBufferShrink)$/;"	f
+BOOST_AUTO_TEST_CASE	muduo/net/tests/Buffer_unittest.cc	/^BOOST_AUTO_TEST_CASE(testMove)$/;"	f
+BOOST_AUTO_TEST_CASE	muduo/net/tests/InetAddress_unittest.cc	/^BOOST_AUTO_TEST_CASE(testInetAddress)$/;"	f
+BOOST_TEST_DYN_LINK	muduo/base/tests/LogStream_test.cc	8;"	d	file:
+BOOST_TEST_DYN_LINK	muduo/net/http/tests/HttpRequest_unittest.cc	6;"	d	file:
+BOOST_TEST_DYN_LINK	muduo/net/tests/Buffer_unittest.cc	5;"	d	file:
+BOOST_TEST_DYN_LINK	muduo/net/tests/InetAddress_unittest.cc	5;"	d	file:
+BOOST_TEST_MAIN	muduo/base/tests/LogStream_test.cc	7;"	d	file:
+BOOST_TEST_MAIN	muduo/net/http/tests/HttpRequest_unittest.cc	5;"	d	file:
+BOOST_TEST_MAIN	muduo/net/tests/Buffer_unittest.cc	4;"	d	file:
+BOOST_TEST_MAIN	muduo/net/tests/InetAddress_unittest.cc	4;"	d	file:
+BUFSIZE	examples/wordcount/slowsink.py	/^BUFSIZE = int(bps\/10) # sleep 100ms at full speed$/;"	v
+Bar	muduo/base/tests/Exception_test.cc	/^class Bar$/;"	c	file:
+Bench	muduo/base/tests/BlockingQueue_bench.cc	/^  Bench(int numThreads)$/;"	f	class:Bench
+Bench	muduo/base/tests/BlockingQueue_bench.cc	/^class Bench$/;"	c	file:
+BlockingQueue	muduo/base/BlockingQueue.h	/^  BlockingQueue()$/;"	f	class:muduo::BlockingQueue
+BlockingQueue	muduo/base/BlockingQueue.h	/^class BlockingQueue : boost::noncopyable$/;"	c	namespace:muduo
+BoilerPlate	muduo/net/boilerplate.h	/^class BoilerPlate : boost::noncopyable$/;"	c	namespace:muduo::net
+BoundedBlockingQueue	muduo/base/BoundedBlockingQueue.h	/^  explicit BoundedBlockingQueue(int maxSize)$/;"	f	class:muduo::BoundedBlockingQueue
+BoundedBlockingQueue	muduo/base/BoundedBlockingQueue.h	/^class BoundedBlockingQueue : boost::noncopyable$/;"	c	namespace:muduo
+Bucket	examples/idleconnection/echo.h	/^  typedef boost::unordered_set<EntryPtr> Bucket;$/;"	t	class:EchoServer
+Buffer	muduo/base/AsyncLogging.h	/^  typedef muduo::detail::FixedBuffer<muduo::detail::kLargeBuffer> Buffer;$/;"	t	class:muduo::AsyncLogging
+Buffer	muduo/base/LogStream.h	/^  typedef detail::FixedBuffer<detail::kSmallBuffer> Buffer;$/;"	t	class:muduo::LogStream
+Buffer	muduo/net/Buffer.h	/^  Buffer()$/;"	f	class:muduo::net::Buffer
+Buffer	muduo/net/Buffer.h	/^class Buffer : public muduo::copyable$/;"	c	namespace:muduo::net
+BufferPtr	muduo/base/AsyncLogging.h	/^  typedef BufferVector::auto_type BufferPtr;$/;"	t	class:muduo::AsyncLogging
+BufferVector	muduo/base/AsyncLogging.h	/^  typedef boost::ptr_vector<Buffer> BufferVector;$/;"	t	class:muduo::AsyncLogging
+ByteSizeConsistencyError	muduo/net/protorpc/google-inl.h	/^void ByteSizeConsistencyError(int byte_size_before_serialization,$/;"	f
+CHECK_NOTNULL	muduo/base/Logging.h	119;"	d
+CURL	examples/curl/Curl.h	/^typedef void CURL;$/;"	t
+CURLM	examples/curl/Curl.h	/^typedef void CURLM;$/;"	t
+CallMethod	muduo/net/protorpc/RpcChannel.cc	/^void RpcChannel::CallMethod(const ::google::protobuf::MethodDescriptor* method,$/;"	f	class:RpcChannel
+Callback	examples/cdns/Resolver.h	/^  typedef boost::function<void(const muduo::net::InetAddress&)> Callback;$/;"	t	class:cdns::Resolver
+Callback	examples/fastcgi/fastcgi.h	/^                                muduo::net::Buffer*)> Callback;$/;"	t	class:FastCgiCodec
+Callback	examples/protobuf/codec/dispatcher.h	/^class Callback : boost::noncopyable$/;"	c
+Callback	muduo/net/inspect/Inspector.h	/^  typedef boost::function<string (HttpRequest::Method, const ArgList& args)> Callback;$/;"	t	class:muduo::net::Inspector
+CallbackMap	examples/protobuf/codec/dispatcher.h	/^  typedef std::map<const google::protobuf::Descriptor*, boost::shared_ptr<Callback> > CallbackMap;$/;"	t	class:ProtobufDispatcher
+CallbackMap	examples/protobuf/codec/dispatcher_lite.h	/^  typedef std::map<const google::protobuf::Descriptor*, ProtobufMessageCallback> CallbackMap;$/;"	t	class:ProtobufDispatcherLite
+CallbackT	examples/protobuf/codec/dispatcher.h	/^  CallbackT(const ProtobufMessageTCallback& callback)$/;"	f	class:CallbackT
+CallbackT	examples/protobuf/codec/dispatcher.h	/^class CallbackT : public Callback$/;"	c
+Channel	muduo/net/Channel.cc	/^Channel::Channel(EventLoop* loop, int fd__)$/;"	f	class:Channel
+Channel	muduo/net/Channel.h	/^class Channel : boost::noncopyable$/;"	c	namespace:muduo::net
+ChannelList	examples/cdns/Resolver.h	/^  typedef boost::ptr_map<int, muduo::net::Channel> ChannelList;$/;"	t	class:cdns::Resolver
+ChannelList	muduo/net/EventLoop.h	/^  typedef std::vector<Channel*> ChannelList;$/;"	t	class:muduo::net::EventLoop
+ChannelList	muduo/net/Poller.h	/^  typedef std::vector<Channel*> ChannelList;$/;"	t	class:muduo::net::Poller
+ChannelMap	muduo/net/poller/EPollPoller.h	/^  typedef std::map<int, Channel*> ChannelMap;$/;"	t	class:muduo::net::EPollPoller
+ChannelMap	muduo/net/poller/PollPoller.h	/^  typedef std::map<int, Channel*> ChannelMap;$/;"	t	class:muduo::net::PollPoller
+ChargenClient	examples/simple/chargenclient/chargenclient.cc	/^  ChargenClient(EventLoop* loop, const InetAddress& listenAddr)$/;"	f	class:ChargenClient
+ChargenClient	examples/simple/chargenclient/chargenclient.cc	/^class ChargenClient : boost::noncopyable$/;"	c	file:
+ChargenServer	examples/simple/chargen/chargen.cc	/^ChargenServer::ChargenServer(EventLoop* loop,$/;"	f	class:ChargenServer
+ChargenServer	examples/simple/chargen/chargen.h	/^class ChargenServer$/;"	c
+ChatClient	examples/asio/chat/client.cc	/^  ChatClient(EventLoop* loop, const InetAddress& serverAddr)$/;"	f	class:ChatClient
+ChatClient	examples/asio/chat/client.cc	/^class ChatClient : boost::noncopyable$/;"	c	file:
+ChatClient	examples/asio/chat/loadtest.cc	/^  ChatClient(EventLoop* loop, const InetAddress& serverAddr)$/;"	f	class:ChatClient
+ChatClient	examples/asio/chat/loadtest.cc	/^class ChatClient : boost::noncopyable$/;"	c	file:
+ChatServer	examples/asio/chat/server.cc	/^  ChatServer(EventLoop* loop,$/;"	f	class:ChatServer
+ChatServer	examples/asio/chat/server.cc	/^class ChatServer : boost::noncopyable$/;"	c	file:
+ChatServer	examples/asio/chat/server_threaded.cc	/^  ChatServer(EventLoop* loop,$/;"	f	class:ChatServer
+ChatServer	examples/asio/chat/server_threaded.cc	/^class ChatServer : boost::noncopyable$/;"	c	file:
+ChatServer	examples/asio/chat/server_threaded_efficient.cc	/^  ChatServer(EventLoop* loop,$/;"	f	class:ChatServer
+ChatServer	examples/asio/chat/server_threaded_efficient.cc	/^class ChatServer : boost::noncopyable$/;"	c	file:
+ChatServer	examples/asio/chat/server_threaded_highperformance.cc	/^  ChatServer(EventLoop* loop,$/;"	f	class:ChatServer
+ChatServer	examples/asio/chat/server_threaded_highperformance.cc	/^class ChatServer : boost::noncopyable$/;"	c	file:
+CheckNotNull	muduo/base/Logging.h	/^T* CheckNotNull(Logger::SourceFile file, int line, const char *names, T* ptr) {$/;"	f	namespace:muduo
+Client	examples/filetransfer/loadtest/Client.java	/^public class Client {$/;"	c
+Client	examples/memcached/client/bench.cc	/^  Client(const string& name,$/;"	f	class:Client
+Client	examples/memcached/client/bench.cc	/^class Client : boost::noncopyable$/;"	c	file:
+Client	examples/pingpong/client.cc	/^  Client(EventLoop* loop,$/;"	f	class:Client
+Client	examples/pingpong/client.cc	/^class Client : boost::noncopyable$/;"	c	file:
+CloseCallback	muduo/net/Callbacks.h	/^typedef boost::function<void (const TcpConnectionPtr&)> CloseCallback;$/;"	t	namespace:muduo::net
+CodecPtr	examples/fastcgi/fastcgi_test.cc	/^typedef boost::shared_ptr<FastCgiCodec> CodecPtr;$/;"	t	file:
+Column	examples/sudoku/sudoku.cc	/^typedef Node Column;$/;"	t	file:
+CommandList	muduo/net/inspect/Inspector.h	/^  typedef std::map<string, Callback> CommandList;$/;"	t	class:muduo::net::Inspector
+Comp	muduo/base/TimeZone.cc	/^  Comp(bool gmt)$/;"	f	struct:muduo::detail::Comp
+Comp	muduo/base/TimeZone.cc	/^struct Comp$/;"	s	namespace:muduo::detail	file:
+Condition	muduo/base/Condition.h	/^  explicit Condition(MutexLock& mutex)$/;"	f	class:muduo::Condition
+Condition	muduo/base/Condition.h	/^class Condition : boost::noncopyable$/;"	c	namespace:muduo
+ConnectionCallback	examples/hub/pubsub.h	/^  typedef boost::function<void (PubSubClient*)> ConnectionCallback;$/;"	t	class:pubsub::PubSubClient
+ConnectionCallback	muduo/net/Callbacks.h	/^typedef boost::function<void (const TcpConnectionPtr&)> ConnectionCallback;$/;"	t	namespace:muduo::net
+ConnectionList	examples/asio/chat/server.cc	/^  typedef std::set<TcpConnectionPtr> ConnectionList;$/;"	t	class:ChatServer	file:
+ConnectionList	examples/asio/chat/server_threaded.cc	/^  typedef std::set<TcpConnectionPtr> ConnectionList;$/;"	t	class:ChatServer	file:
+ConnectionList	examples/asio/chat/server_threaded_efficient.cc	/^  typedef std::set<TcpConnectionPtr> ConnectionList;$/;"	t	class:ChatServer	file:
+ConnectionList	examples/asio/chat/server_threaded_highperformance.cc	/^  typedef std::set<TcpConnectionPtr> ConnectionList;$/;"	t	class:ChatServer	file:
+ConnectionListPtr	examples/asio/chat/server_threaded_efficient.cc	/^  typedef boost::shared_ptr<ConnectionList> ConnectionListPtr;$/;"	t	class:ChatServer	file:
+ConnectionMap	muduo/net/TcpServer.h	/^  typedef std::map<string, TcpConnectionPtr> ConnectionMap;$/;"	t	class:muduo::net::TcpServer
+ConnectionSubscription	examples/hub/hub.cc	/^typedef std::set<string> ConnectionSubscription;$/;"	t	namespace:pubsub	file:
+Connector	muduo/net/Connector.cc	/^Connector::Connector(EventLoop* loop, const InetAddress& serverAddr)$/;"	f	class:Connector
+Connector	muduo/net/Connector.h	/^class Connector : boost::noncopyable,$/;"	c	namespace:muduo::net
+ConnectorPtr	muduo/net/TcpClient.h	/^typedef boost::shared_ptr<Connector> ConnectorPtr;$/;"	t	namespace:muduo::net
+ConstItemPtr	examples/memcached/server/Item.h	/^typedef boost::shared_ptr<const Item> ConstItemPtr;  \/\/ TODO: use unique_ptr$/;"	t
+CopyToStdString	muduo/base/StringPiece.h	/^  void CopyToStdString(std::string* target) const {$/;"	f	class:muduo::StringPiece
+CopyToString	muduo/base/StringPiece.h	/^  void CopyToString(string* target) const {$/;"	f	class:muduo::StringPiece
+CountDownLatch	muduo/base/CountDownLatch.cc	/^CountDownLatch::CountDownLatch(int count)$/;"	f	class:CountDownLatch
+CountDownLatch	muduo/base/CountDownLatch.h	/^class CountDownLatch : boost::noncopyable$/;"	c	namespace:muduo
+Curl	examples/curl/Curl.cc	/^Curl::Curl(EventLoop* loop)$/;"	f	class:Curl
+Curl	examples/curl/Curl.h	/^class Curl : boost::noncopyable$/;"	c	namespace:curl
+CurrentThread	muduo/base/CurrentThread.h	/^namespace CurrentThread$/;"	n	namespace:muduo
+CurrentThread	muduo/base/Thread.cc	/^namespace CurrentThread$/;"	n	namespace:muduo	file:
+DEBUG	muduo/base/Logging.h	/^    DEBUG,$/;"	e	enum:muduo::Logger::LogLevel
+Data	muduo/base/TimeZone.cc	/^struct TimeZone::Data$/;"	s	class:TimeZone	file:
+DataCallback	examples/curl/Curl.h	/^  typedef boost::function<void(const char*, int)> DataCallback;$/;"	t	class:curl::Request
+DataEvent	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/DataEvent.java	/^    public DataEvent(EventSource source, int whichClient, ChannelBuffer data) {$/;"	m	class:DataEvent
+DataEvent	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/DataEvent.java	/^public class DataEvent extends Event {$/;"	c
+Date	muduo/base/Date.cc	/^Date::Date(const struct tm& t)$/;"	f	class:Date
+Date	muduo/base/Date.cc	/^Date::Date(int y, int m, int d)$/;"	f	class:Date
+Date	muduo/base/Date.h	/^  Date()$/;"	f	class:muduo::Date
+Date	muduo/base/Date.h	/^  explicit Date(int julianDayNum)$/;"	f	class:muduo::Date
+Date	muduo/base/Date.h	/^class Date : public muduo::copyable$/;"	c	namespace:muduo
+DaytimeServer	examples/simple/daytime/daytime.cc	/^DaytimeServer::DaytimeServer(EventLoop* loop,$/;"	f	class:DaytimeServer
+DaytimeServer	examples/simple/daytime/daytime.h	/^class DaytimeServer$/;"	c
+Deleter	muduo/base/ThreadLocalSingleton.h	/^    Deleter()$/;"	f	class:muduo::ThreadLocalSingleton::Deleter
+Deleter	muduo/base/ThreadLocalSingleton.h	/^  class Deleter$/;"	c	class:muduo::ThreadLocalSingleton
+DemuxServer	examples/multiplexer/demux.cc	/^  DemuxServer(EventLoop* loop, const InetAddress& listenAddr, const InetAddress& socksAddr)$/;"	f	class:DemuxServer
+DemuxServer	examples/multiplexer/demux.cc	/^class DemuxServer : boost::noncopyable$/;"	c	file:
+DiscardClient	examples/netty/discard/client.cc	/^  DiscardClient(EventLoop* loop, const InetAddress& listenAddr, int size)$/;"	f	class:DiscardClient
+DiscardClient	examples/netty/discard/client.cc	/^class DiscardClient : boost::noncopyable$/;"	c	file:
+DiscardServer	examples/netty/discard/server.cc	/^  DiscardServer(EventLoop* loop, const InetAddress& listenAddr)$/;"	f	class:DiscardServer
+DiscardServer	examples/netty/discard/server.cc	/^class DiscardServer$/;"	c	file:
+DiscardServer	examples/simple/discard/discard.cc	/^DiscardServer::DiscardServer(EventLoop* loop,$/;"	f	class:DiscardServer
+DiscardServer	examples/simple/discard/discard.h	/^class DiscardServer$/;"	c
+DoneCallback	examples/curl/Curl.h	/^  typedef boost::function<void(Request*, int)> DoneCallback;$/;"	t	class:curl::Request
+DoneCallback	examples/sudoku/client.cc	/^typedef boost::function<void(const string&, double)> DoneCallback;$/;"	t	file:
+Downloader	examples/curl/download.cc	/^  Downloader(EventLoop* loop, const string& url)$/;"	f	class:Downloader
+Downloader	examples/curl/download.cc	/^class Downloader : boost::noncopyable$/;"	c	file:
+EPollPoller	muduo/net/poller/EPollPoller.cc	/^EPollPoller::EPollPoller(EventLoop* loop)$/;"	f	class:EPollPoller
+EPollPoller	muduo/net/poller/EPollPoller.h	/^class EPollPoller : public Poller$/;"	c	namespace:muduo::net
+ERROR	muduo/base/Logging.h	/^    ERROR,$/;"	e	enum:muduo::Logger::LogLevel
+Echo	examples/protobuf/rpcbench/server.cc	/^  virtual void Echo(::google::protobuf::RpcController* controller,$/;"	f	class:echo::EchoServiceImpl
+EchoClient	examples/netty/echo/client.cc	/^  EchoClient(EventLoop* loop, const InetAddress& listenAddr, int size)$/;"	f	class:EchoClient
+EchoClient	examples/netty/echo/client.cc	/^class EchoClient : boost::noncopyable$/;"	c	file:
+EchoClient	muduo/net/tests/EchoClient_unittest.cc	/^  EchoClient(EventLoop* loop, const InetAddress& listenAddr, const string& id)$/;"	f	class:EchoClient
+EchoClient	muduo/net/tests/EchoClient_unittest.cc	/^class EchoClient : boost::noncopyable$/;"	c	file:
+EchoServer	examples/idleconnection/echo.cc	/^EchoServer::EchoServer(EventLoop* loop,$/;"	f	class:EchoServer
+EchoServer	examples/idleconnection/echo.h	/^class EchoServer$/;"	c
+EchoServer	examples/idleconnection/sortedlist.cc	/^EchoServer::EchoServer(EventLoop* loop,$/;"	f	class:EchoServer
+EchoServer	examples/idleconnection/sortedlist.cc	/^class EchoServer$/;"	c	file:
+EchoServer	examples/maxconnection/echo.cc	/^EchoServer::EchoServer(EventLoop* loop,$/;"	f	class:EchoServer
+EchoServer	examples/maxconnection/echo.h	/^class EchoServer$/;"	c
+EchoServer	examples/netty/echo/server.cc	/^  EchoServer(EventLoop* loop, const InetAddress& listenAddr)$/;"	f	class:EchoServer
+EchoServer	examples/netty/echo/server.cc	/^class EchoServer$/;"	c	file:
+EchoServer	examples/simple/echo/echo.cc	/^EchoServer::EchoServer(muduo::net::EventLoop* loop,$/;"	f	class:EchoServer
+EchoServer	examples/simple/echo/echo.h	/^class EchoServer$/;"	c
+EchoServer	muduo/net/tests/EchoServer_unittest.cc	/^  EchoServer(EventLoop* loop, const InetAddress& listenAddr)$/;"	f	class:EchoServer
+EchoServer	muduo/net/tests/EchoServer_unittest.cc	/^class EchoServer$/;"	c	file:
+EchoServiceImpl	examples/protobuf/rpcbench/server.cc	/^class EchoServiceImpl : public EchoService$/;"	c	namespace:echo	file:
+EmptyPtr	examples/protobuf/codec/client.cc	/^typedef boost::shared_ptr<muduo::Empty> EmptyPtr;$/;"	t	file:
+Entry	examples/idleconnection/echo.h	/^    explicit Entry(const WeakTcpConnectionPtr& weakConn)$/;"	f	struct:EchoServer::Entry
+Entry	examples/idleconnection/echo.h	/^  struct Entry : public muduo::copyable$/;"	s	class:EchoServer
+Entry	examples/multiplexer/demux.cc	/^struct Entry$/;"	s	file:
+Entry	muduo/net/TimerQueue.h	/^  typedef std::pair<Timestamp, Timer*> Entry;$/;"	t	class:muduo::net::TimerQueue
+EntryPtr	examples/idleconnection/echo.h	/^  typedef boost::shared_ptr<Entry> EntryPtr;$/;"	t	class:EchoServer
+Equal	examples/memcached/server/MemcacheServer.h	/^  struct Equal$/;"	s	class:MemcacheServer
+ErrorCallback	examples/protobuf/codec/codec.h	/^                                ErrorCode)> ErrorCallback;$/;"	t	class:ProtobufCodec
+ErrorCallback	muduo/net/protorpc/RpcCodec.h	/^                                ErrorCode)> ErrorCallback;$/;"	t	class:muduo::net::RpcCodec
+ErrorCode	examples/protobuf/codec/codec.h	/^  enum ErrorCode$/;"	g	class:ProtobufCodec
+ErrorCode	muduo/net/protorpc/RpcCodec.h	/^  enum ErrorCode$/;"	g	class:muduo::net::RpcCodec
+Event	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/Event.java	/^public class Event {$/;"	c
+EventCallback	muduo/net/Channel.h	/^  typedef boost::function<void()> EventCallback;$/;"	t	class:muduo::net::Channel
+EventList	muduo/net/poller/EPollPoller.h	/^  typedef std::vector<struct epoll_event> EventList;$/;"	t	class:muduo::net::EPollPoller
+EventLoop	muduo/net/EventLoop.cc	/^EventLoop::EventLoop()$/;"	f	class:EventLoop
+EventLoop	muduo/net/EventLoop.h	/^class EventLoop : boost::noncopyable$/;"	c	namespace:muduo::net
+EventLoopThread	muduo/net/EventLoopThread.cc	/^EventLoopThread::EventLoopThread(const ThreadInitCallback& cb)$/;"	f	class:EventLoopThread
+EventLoopThread	muduo/net/EventLoopThread.h	/^class EventLoopThread : boost::noncopyable$/;"	c	namespace:muduo::net
+EventLoopThreadPool	muduo/net/EventLoopThreadPool.cc	/^EventLoopThreadPool::EventLoopThreadPool(EventLoop* baseLoop)$/;"	f	class:EventLoopThreadPool
+EventLoopThreadPool	muduo/net/EventLoopThreadPool.h	/^class EventLoopThreadPool : boost::noncopyable$/;"	c	namespace:muduo::net
+EventQueue	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/EventQueue.java	/^public class EventQueue {$/;"	c
+EventSource	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/EventSource.java	/^public enum EventSource {$/;"	g
+Exception	muduo/base/Exception.cc	/^Exception::Exception(const char* msg)$/;"	f	class:Exception
+Exception	muduo/base/Exception.cc	/^Exception::Exception(const string& msg)$/;"	f	class:Exception
+Exception	muduo/base/Exception.h	/^class Exception : public std::exception$/;"	c	namespace:muduo
+FATAL	muduo/base/Logging.h	/^    FATAL,$/;"	e	enum:muduo::Logger::LogLevel
+FastCgiCodec	examples/fastcgi/fastcgi.h	/^  explicit FastCgiCodec(const Callback& cb)$/;"	f	class:FastCgiCodec
+FastCgiCodec	examples/fastcgi/fastcgi.h	/^class FastCgiCodec : boost::noncopyable$/;"	c
+FcgiConstant	examples/fastcgi/fastcgi.cc	/^enum FcgiConstant$/;"	g	file:
+FcgiRole	examples/fastcgi/fastcgi.cc	/^enum FcgiRole$/;"	g	file:
+FcgiType	examples/fastcgi/fastcgi.cc	/^enum FcgiType$/;"	g	file:
+File	muduo/base/LogFile.cc	/^  explicit File(const string& filename)$/;"	f	class:LogFile::File
+File	muduo/base/LogFile.cc	/^class LogFile::File : boost::noncopyable$/;"	c	class:LogFile	file:
+File	muduo/base/TimeZone.cc	/^  File(const char* file)$/;"	f	class:muduo::detail::File
+File	muduo/base/TimeZone.cc	/^class File : boost::noncopyable$/;"	c	namespace:muduo::detail	file:
+FilePtr	examples/curl/download.cc	/^typedef boost::shared_ptr<FILE> FilePtr;$/;"	t	file:
+FilePtr	examples/filetransfer/download3.cc	/^typedef boost::shared_ptr<FILE> FilePtr;$/;"	t	file:
+FileUtil	muduo/base/FileUtil.h	/^namespace FileUtil$/;"	n	namespace:muduo
+FixedBuffer	muduo/base/LogStream.h	/^  FixedBuffer()$/;"	f	class:muduo::detail::FixedBuffer
+FixedBuffer	muduo/base/LogStream.h	/^class FixedBuffer : boost::noncopyable$/;"	c	namespace:muduo::detail
+FlushFunc	muduo/base/Logging.h	/^  typedef void (*FlushFunc)();$/;"	t	class:muduo::Logger
+Fmt	muduo/base/LogStream.cc	/^Fmt::Fmt(const char* fmt, T val)$/;"	f	class:Fmt
+Fmt	muduo/base/LogStream.h	/^class Fmt \/\/ : boost::noncopyable$/;"	c	namespace:muduo
+Foo	muduo/base/tests/Thread_test.cc	/^  explicit Foo(double x)$/;"	f	class:Foo
+Foo	muduo/base/tests/Thread_test.cc	/^class Foo$/;"	c	file:
+Functor	muduo/net/EventLoop.h	/^  typedef boost::function<void()> Functor;$/;"	t	class:muduo::net::EventLoop
+Handler	examples/filetransfer/loadtest/Handler.java	/^    public Handler(int maxLength, CountDownLatch latch) throws Exception {$/;"	m	class:Handler
+Handler	examples/filetransfer/loadtest/Handler.java	/^public class Handler extends SimpleChannelUpstreamHandler {$/;"	c
+Handler	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/MockBackendServer.java	/^    private class Handler extends SimpleChannelHandler {$/;"	c	class:MockBackendServer
+Handler	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/MockClient.java	/^    private class Handler extends SimpleChannelHandler {$/;"	c	class:MockClient
+Hash	examples/memcached/server/MemcacheServer.h	/^  struct Hash$/;"	s	class:MemcacheServer
+HelpList	muduo/net/inspect/Inspector.h	/^  typedef std::map<string, string> HelpList;$/;"	t	class:muduo::net::Inspector
+HighWaterMarkCallback	muduo/net/Callbacks.h	/^typedef boost::function<void (const TcpConnectionPtr&, size_t)> HighWaterMarkCallback;$/;"	t	namespace:muduo::net
+HttpCallback	muduo/net/http/HttpServer.h	/^                                HttpResponse*)> HttpCallback;$/;"	t	class:muduo::net::HttpServer
+HttpContext	muduo/net/http/HttpContext.h	/^  HttpContext()$/;"	f	class:muduo::net::HttpContext
+HttpContext	muduo/net/http/HttpContext.h	/^class HttpContext : public muduo::copyable$/;"	c	namespace:muduo::net
+HttpRequest	muduo/net/http/HttpRequest.h	/^  HttpRequest()$/;"	f	class:muduo::net::HttpRequest
+HttpRequest	muduo/net/http/HttpRequest.h	/^class HttpRequest : public muduo::copyable$/;"	c	namespace:muduo::net
+HttpRequestParseState	muduo/net/http/HttpContext.h	/^  enum HttpRequestParseState$/;"	g	class:muduo::net::HttpContext
+HttpResponse	muduo/net/http/HttpResponse.h	/^  explicit HttpResponse(bool close)$/;"	f	class:muduo::net::HttpResponse
+HttpResponse	muduo/net/http/HttpResponse.h	/^class HttpResponse : public muduo::copyable$/;"	c	namespace:muduo::net
+HttpServer	muduo/net/http/HttpServer.cc	/^HttpServer::HttpServer(EventLoop* loop,$/;"	f	class:HttpServer
+HttpServer	muduo/net/http/HttpServer.h	/^class HttpServer : boost::noncopyable$/;"	c	namespace:muduo::net
+HttpStatusCode	muduo/net/http/HttpResponse.h	/^  enum HttpStatusCode$/;"	g	class:muduo::net::HttpResponse
+INFO	muduo/base/Logging.h	/^    INFO,$/;"	e	enum:muduo::Logger::LogLevel
+IgnoreSigPipe	muduo/net/EventLoop.cc	/^  IgnoreSigPipe()$/;"	f	class:__anon4::IgnoreSigPipe
+IgnoreSigPipe	muduo/net/EventLoop.cc	/^class IgnoreSigPipe$/;"	c	namespace:__anon4	file:
+Impl	muduo/base/Logging.cc	/^Logger::Impl::Impl(LogLevel level, int savedErrno, const SourceFile& file, int line)$/;"	f	class:Logger::Impl
+Impl	muduo/base/Logging.h	/^class Impl$/;"	c	class:muduo::Logger
+InetAddress	muduo/net/InetAddress.cc	/^InetAddress::InetAddress(const StringPiece& ip, uint16_t port)$/;"	f	class:InetAddress
+InetAddress	muduo/net/InetAddress.cc	/^InetAddress::InetAddress(uint16_t port)$/;"	f	class:InetAddress
+InetAddress	muduo/net/InetAddress.h	/^  InetAddress(const struct sockaddr_in& addr)$/;"	f	class:muduo::net::InetAddress
+InetAddress	muduo/net/InetAddress.h	/^class InetAddress : public muduo::copyable$/;"	c	namespace:muduo::net
+InitializationErrorMessage	muduo/net/protorpc/google-inl.h	/^std::string InitializationErrorMessage(const char* action,$/;"	f
+Input	examples/sudoku/client.cc	/^typedef std::vector<string> Input;$/;"	t	file:
+InputPtr	examples/sudoku/client.cc	/^typedef boost::shared_ptr<Input> InputPtr;$/;"	t	file:
+Inspector	muduo/net/inspect/Inspector.cc	/^Inspector::Inspector(EventLoop* loop,$/;"	f	class:Inspector
+Inspector	muduo/net/inspect/Inspector.h	/^class Inspector : boost::noncopyable$/;"	c	namespace:muduo::net
+Item	examples/memcached/server/Item.cc	/^Item::Item(StringPiece keyArg,$/;"	f	class:Item
+Item	examples/memcached/server/Item.h	/^class Item : boost::noncopyable$/;"	c
+ItemMap	examples/memcached/server/MemcacheServer.h	/^  typedef boost::unordered_set<ConstItemPtr, Hash, Equal> ItemMap;$/;"	t	class:MemcacheServer
+ItemPtr	examples/memcached/server/Item.h	/^typedef boost::shared_ptr<Item> ItemPtr;  \/\/ TODO: use unique_ptr$/;"	t
+LOG_DEBUG	muduo/base/Logging.h	102;"	d
+LOG_ERROR	muduo/base/Logging.h	107;"	d
+LOG_FATAL	muduo/base/Logging.h	108;"	d
+LOG_INFO	muduo/base/Logging.h	104;"	d
+LOG_SYSERR	muduo/base/Logging.h	109;"	d
+LOG_SYSFATAL	muduo/base/Logging.h	110;"	d
+LOG_TRACE	muduo/base/Logging.h	100;"	d
+LOG_WARN	muduo/base/Logging.h	106;"	d
+LengthHeaderCodec	examples/asio/chat/codec.h	/^  explicit LengthHeaderCodec(const StringMessageCallback& cb)$/;"	f	class:LengthHeaderCodec
+LengthHeaderCodec	examples/asio/chat/codec.h	/^class LengthHeaderCodec : boost::noncopyable$/;"	c
+LocalConnections	examples/asio/chat/server_threaded_highperformance.cc	/^  typedef ThreadLocalSingleton<ConnectionList> LocalConnections;$/;"	t	class:ChatServer	file:
+Localtime	muduo/base/TimeZone.cc	/^  Localtime(time_t offset, bool dst, int arrb)$/;"	f	struct:muduo::detail::Localtime
+Localtime	muduo/base/TimeZone.cc	/^struct Localtime$/;"	s	namespace:muduo::detail	file:
+LogFile	muduo/base/LogFile.cc	/^LogFile::LogFile(const string& basename,$/;"	f	class:LogFile
+LogFile	muduo/base/LogFile.h	/^class LogFile : boost::noncopyable$/;"	c	namespace:muduo
+LogLevel	muduo/base/Logging.h	/^  enum LogLevel$/;"	g	class:muduo::Logger
+LogLevel	muduo/base/Logging.h	/^  typedef Logger::LogLevel LogLevel;$/;"	t	class:muduo::Logger::Impl
+LogLevelName	muduo/base/Logging.cc	/^const char* LogLevelName[Logger::NUM_LOG_LEVELS] =$/;"	m	namespace:muduo	file:
+LogStream	muduo/base/LogStream.h	/^class LogStream : boost::noncopyable$/;"	c	namespace:muduo
+Logger	muduo/base/Logging.cc	/^Logger::Logger(SourceFile file, int line)$/;"	f	class:Logger
+Logger	muduo/base/Logging.cc	/^Logger::Logger(SourceFile file, int line, LogLevel level)$/;"	f	class:Logger
+Logger	muduo/base/Logging.cc	/^Logger::Logger(SourceFile file, int line, LogLevel level, const char* func)$/;"	f	class:Logger
+Logger	muduo/base/Logging.cc	/^Logger::Logger(SourceFile file, int line, bool toAbort)$/;"	f	class:Logger
+Logger	muduo/base/Logging.h	/^class Logger$/;"	c	namespace:muduo
+MCHECK	muduo/base/Mutex.h	26;"	d
+MUDUO_BASE_ASYNCLOGGING_H	muduo/base/AsyncLogging.h	2;"	d
+MUDUO_BASE_ATOMIC_H	muduo/base/Atomic.h	7;"	d
+MUDUO_BASE_BLOCKINGQUEUE_H	muduo/base/BlockingQueue.h	7;"	d
+MUDUO_BASE_BOUNDEDBLOCKINGQUEUE_H	muduo/base/BoundedBlockingQueue.h	7;"	d
+MUDUO_BASE_CONDITION_H	muduo/base/Condition.h	7;"	d
+MUDUO_BASE_COPYABLE_H	muduo/base/copyable.h	2;"	d
+MUDUO_BASE_COUNTDOWNLATCH_H	muduo/base/CountDownLatch.h	7;"	d
+MUDUO_BASE_CURRENTTHREAD_H	muduo/base/CurrentThread.h	7;"	d
+MUDUO_BASE_DATE_H	muduo/base/Date.h	7;"	d
+MUDUO_BASE_EXCEPTION_H	muduo/base/Exception.h	7;"	d
+MUDUO_BASE_FILEUTIL_H	muduo/base/FileUtil.h	12;"	d
+MUDUO_BASE_LOGFILE_H	muduo/base/LogFile.h	2;"	d
+MUDUO_BASE_LOGGING_H	muduo/base/Logging.h	2;"	d
+MUDUO_BASE_LOGSTREAM_H	muduo/base/LogStream.h	2;"	d
+MUDUO_BASE_MUTEX_H	muduo/base/Mutex.h	7;"	d
+MUDUO_BASE_PROCESSINFO_H	muduo/base/ProcessInfo.h	12;"	d
+MUDUO_BASE_SINGLETON_H	muduo/base/Singleton.h	7;"	d
+MUDUO_BASE_STRINGPIECE_H	muduo/base/StringPiece.h	41;"	d
+MUDUO_BASE_THREADLOCALSINGLETON_H	muduo/base/ThreadLocalSingleton.h	7;"	d
+MUDUO_BASE_THREADLOCAL_H	muduo/base/ThreadLocal.h	7;"	d
+MUDUO_BASE_THREADPOOL_H	muduo/base/ThreadPool.h	7;"	d
+MUDUO_BASE_THREAD_H	muduo/base/Thread.h	7;"	d
+MUDUO_BASE_TIMESTAMP_H	muduo/base/Timestamp.h	2;"	d
+MUDUO_BASE_TIMEZONE_H	muduo/base/TimeZone.h	9;"	d
+MUDUO_BASE_TYPES_H	muduo/base/Types.h	2;"	d
+MUDUO_EXAMPLES_ASIO_CHAT_CODEC_H	examples/asio/chat/codec.h	2;"	d
+MUDUO_EXAMPLES_CDNS_RESOLVER_H	examples/cdns/Resolver.h	2;"	d
+MUDUO_EXAMPLES_CURL_CURL_H	examples/curl/Curl.h	2;"	d
+MUDUO_EXAMPLES_FASTCGI_FASTCGI_H	examples/fastcgi/fastcgi.h	2;"	d
+MUDUO_EXAMPLES_HUB_CODEC_H	examples/hub/codec.h	2;"	d
+MUDUO_EXAMPLES_HUB_PUBSUB_H	examples/hub/pubsub.h	2;"	d
+MUDUO_EXAMPLES_IDLECONNECTION_ECHO_H	examples/idleconnection/echo.h	2;"	d
+MUDUO_EXAMPLES_MEMCACHED_SERVER_ITEM_H	examples/memcached/server/Item.h	2;"	d
+MUDUO_EXAMPLES_MEMCACHED_SERVER_MEMCACHESERVER_H	examples/memcached/server/MemcacheServer.h	2;"	d
+MUDUO_EXAMPLES_MEMCACHED_SERVER_SESSION_H	examples/memcached/server/Session.h	2;"	d
+MUDUO_EXAMPLES_PROTOBUF_CODEC_CODEC_H	examples/protobuf/codec/codec.h	10;"	d
+MUDUO_EXAMPLES_PROTOBUF_CODEC_DISPATCHER_H	examples/protobuf/codec/dispatcher.h	10;"	d
+MUDUO_EXAMPLES_PROTOBUF_CODEC_DISPATCHER_LITE_H	examples/protobuf/codec/dispatcher_lite.h	10;"	d
+MUDUO_EXAMPLES_SIMPLE_CHARGEN_CHARGEN_H	examples/simple/chargen/chargen.h	2;"	d
+MUDUO_EXAMPLES_SIMPLE_DAYTIME_DAYTIME_H	examples/simple/daytime/daytime.h	2;"	d
+MUDUO_EXAMPLES_SIMPLE_DISCARD_DISCARD_H	examples/simple/discard/discard.h	2;"	d
+MUDUO_EXAMPLES_SIMPLE_ECHO_ECHO_H	examples/maxconnection/echo.h	2;"	d
+MUDUO_EXAMPLES_SIMPLE_ECHO_ECHO_H	examples/simple/echo/echo.h	2;"	d
+MUDUO_EXAMPLES_SIMPLE_TIME_TIME_H	examples/simple/time/time.h	2;"	d
+MUDUO_EXAMPLES_SOCKS4A_TUNNEL_H	examples/socks4a/tunnel.h	2;"	d
+MUDUO_EXAMPLES_SUDOKU_SUDOKU_H	examples/sudoku/sudoku.h	2;"	d
+MUDUO_EXAMPLES_WORDCOUNT_HASH_H	examples/wordcount/hash.h	2;"	d
+MUDUO_NET_ACCEPTOR_H	muduo/net/Acceptor.h	12;"	d
+MUDUO_NET_BOILERPLATE_H	muduo/net/boilerplate.h	13;"	d
+MUDUO_NET_BUFFER_H	muduo/net/Buffer.h	12;"	d
+MUDUO_NET_CALLBACKS_H	muduo/net/Callbacks.h	12;"	d
+MUDUO_NET_CHANNEL_H	muduo/net/Channel.h	12;"	d
+MUDUO_NET_CONNECTOR_H	muduo/net/Connector.h	12;"	d
+MUDUO_NET_ENDIAN_H	muduo/net/Endian.h	12;"	d
+MUDUO_NET_EVENTLOOPTHREADPOOL_H	muduo/net/EventLoopThreadPool.h	12;"	d
+MUDUO_NET_EVENTLOOPTHREAD_H	muduo/net/EventLoopThread.h	12;"	d
+MUDUO_NET_EVENTLOOP_H	muduo/net/EventLoop.h	12;"	d
+MUDUO_NET_HTTP_HTTPCONTEXT_H	muduo/net/http/HttpContext.h	12;"	d
+MUDUO_NET_HTTP_HTTPREQUEST_H	muduo/net/http/HttpRequest.h	12;"	d
+MUDUO_NET_HTTP_HTTPRESPONSE_H	muduo/net/http/HttpResponse.h	12;"	d
+MUDUO_NET_HTTP_HTTPSERVER_H	muduo/net/http/HttpServer.h	12;"	d
+MUDUO_NET_INETADDRESS_H	muduo/net/InetAddress.h	12;"	d
+MUDUO_NET_INSPECT_INSPECTOR_H	muduo/net/inspect/Inspector.h	12;"	d
+MUDUO_NET_INSPECT_PERFORMANCEINSPECTOR_H	muduo/net/inspect/PerformanceInspector.h	12;"	d
+MUDUO_NET_INSPECT_PROCESSINSPECTOR_H	muduo/net/inspect/ProcessInspector.h	12;"	d
+MUDUO_NET_POLLER_EPOLLPOLLER_H	muduo/net/poller/EPollPoller.h	12;"	d
+MUDUO_NET_POLLER_H	muduo/net/Poller.h	12;"	d
+MUDUO_NET_POLLER_POLLPOLLER_H	muduo/net/poller/PollPoller.h	12;"	d
+MUDUO_NET_PROTORPC_RPCCHANNEL_H	muduo/net/protorpc/RpcChannel.h	12;"	d
+MUDUO_NET_PROTORPC_RPCCODEC_H	muduo/net/protorpc/RpcCodec.h	12;"	d
+MUDUO_NET_PROTORPC_RPCSERVER_H	muduo/net/protorpc/RpcServer.h	12;"	d
+MUDUO_NET_SOCKETSOPS_H	muduo/net/SocketsOps.h	12;"	d
+MUDUO_NET_SOCKET_H	muduo/net/Socket.h	12;"	d
+MUDUO_NET_TCPCLIENT_H	muduo/net/TcpClient.h	12;"	d
+MUDUO_NET_TCPCONNECTION_H	muduo/net/TcpConnection.h	12;"	d
+MUDUO_NET_TCPSERVER_H	muduo/net/TcpServer.h	12;"	d
+MUDUO_NET_TIMERID_H	muduo/net/TimerId.h	12;"	d
+MUDUO_NET_TIMERQUEUE_H	muduo/net/TimerQueue.h	12;"	d
+MUDUO_NET_TIMER_H	muduo/net/Timer.h	12;"	d
+MapWithLock	examples/memcached/server/MemcacheServer.h	/^  struct MapWithLock$/;"	s	class:MemcacheServer
+MemcacheServer	examples/memcached/server/MemcacheServer.cc	/^MemcacheServer::MemcacheServer(muduo::net::EventLoop* loop, const Options& options)$/;"	f	class:MemcacheServer
+MemcacheServer	examples/memcached/server/MemcacheServer.h	/^class MemcacheServer : boost::noncopyable$/;"	c
+MessageCallback	muduo/net/Callbacks.h	/^                              Timestamp)> MessageCallback;$/;"	t	namespace:muduo::net
+MessagePtr	examples/protobuf/codec/codec.h	/^typedef boost::shared_ptr<google::protobuf::Message> MessagePtr;$/;"	t
+MessagePtr	examples/protobuf/codec/dispatcher.h	/^typedef boost::shared_ptr<google::protobuf::Message> MessagePtr;$/;"	t
+MessagePtr	examples/protobuf/codec/dispatcher_lite.h	/^typedef boost::shared_ptr<google::protobuf::Message> MessagePtr;$/;"	t
+Method	muduo/net/http/HttpRequest.h	/^  enum Method$/;"	g	class:muduo::net::HttpRequest
+MockBackendServer	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/MockBackendServer.java	/^    public MockBackendServer(EventQueue queue, int listeningPort, Executor boss, Executor worker,$/;"	m	class:MockBackendServer
+MockBackendServer	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/MockBackendServer.java	/^public class MockBackendServer {$/;"	c
+MockClient	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/MockClient.java	/^    public MockClient(EventQueue queue, InetSocketAddress remoteAddress, Executor boss,$/;"	m	class:MockClient
+MockClient	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/MockClient.java	/^public class MockClient {$/;"	c
+MultiplexServer	examples/multiplexer/multiplexer.cc	/^  MultiplexServer(EventLoop* loop,$/;"	f	class:MultiplexServer
+MultiplexServer	examples/multiplexer/multiplexer.cc	/^class MultiplexServer$/;"	c	file:
+MultiplexServer	examples/multiplexer/multiplexer_simple.cc	/^  MultiplexServer(EventLoop* loop, const InetAddress& listenAddr, const InetAddress& backendAddr)$/;"	f	class:MultiplexServer
+MultiplexServer	examples/multiplexer/multiplexer_simple.cc	/^class MultiplexServer : boost::noncopyable$/;"	c	file:
+MultiplexerTest	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/MultiplexerTest.java	/^    public MultiplexerTest(String multiplexerHost) {$/;"	m	class:MultiplexerTest
+MultiplexerTest	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/MultiplexerTest.java	/^public class MultiplexerTest {$/;"	c
+MutexLock	muduo/base/Mutex.h	/^  MutexLock()$/;"	f	class:muduo::MutexLock
+MutexLock	muduo/base/Mutex.h	/^class MutexLock : boost::noncopyable$/;"	c	namespace:muduo
+MutexLockGuard	muduo/base/Mutex.h	/^  explicit MutexLockGuard(MutexLock& mutex)$/;"	f	class:muduo::MutexLockGuard
+MutexLockGuard	muduo/base/Mutex.h	/^class MutexLockGuard : boost::noncopyable$/;"	c	namespace:muduo
+MutexLockGuard	muduo/base/Mutex.h	161;"	d
+MyCountDownLatch	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/MyCountDownLatch.java	/^    public MyCountDownLatch(int count) {$/;"	m	class:MyCountDownLatch
+MyCountDownLatch	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/MyCountDownLatch.java	/^public class MyCountDownLatch extends CountDownLatch {$/;"	c
+N	muduo/base/tests/LogStream_bench.cc	/^const size_t N = 1000000;$/;"	v
+NUM_LOG_LEVELS	muduo/base/Logging.h	/^    NUM_LOG_LEVELS,$/;"	e	enum:muduo::Logger::LogLevel
+NewConnectionCallback	muduo/net/Acceptor.h	/^                                const InetAddress&)> NewConnectionCallback;$/;"	t	class:muduo::net::Acceptor
+NewConnectionCallback	muduo/net/Connector.h	/^  typedef boost::function<void (int sockfd)> NewConnectionCallback;$/;"	t	class:muduo::net::Connector
+Node	examples/idleconnection/sortedlist.cc	/^  struct Node : public muduo::copyable$/;"	s	class:EchoServer	file:
+Node	examples/sudoku/sudoku.cc	/^struct Node$/;"	s	file:
+Operation	examples/memcached/client/bench.cc	/^  enum Operation$/;"	g	class:Client	file:
+Option	examples/cdns/Resolver.h	/^  enum Option$/;"	g	class:cdns::Resolver
+Option	examples/curl/Curl.h	/^  enum Option$/;"	g	class:curl::Curl
+Option	muduo/net/TcpServer.h	/^  enum Option$/;"	g	class:muduo::net::TcpServer
+Options	examples/memcached/server/MemcacheServer.cc	/^MemcacheServer::Options::Options()$/;"	f	class:MemcacheServer::Options
+Options	examples/memcached/server/MemcacheServer.h	/^  struct Options$/;"	s	class:MemcacheServer
+OutputFunc	muduo/base/Logging.h	/^  typedef void (*OutputFunc)(const char* msg, int len);$/;"	t	class:muduo::Logger
+OutstandingCall	muduo/net/protorpc/RpcChannel.h	/^  struct OutstandingCall$/;"	s	class:muduo::net::RpcChannel
+ParamMap	examples/fastcgi/fastcgi.h	/^  typedef std::map<string, string> ParamMap;$/;"	t	class:FastCgiCodec
+ParseResult	examples/hub/codec.h	/^enum ParseResult$/;"	g	namespace:pubsub
+PerformanceInspector	muduo/net/inspect/PerformanceInspector.h	/^class PerformanceInspector : boost::noncopyable$/;"	c	namespace:muduo::net
+Piece	examples/curl/download.cc	/^  Piece(const curl::RequestPtr& req,$/;"	f	class:Piece
+Piece	examples/curl/download.cc	/^class Piece : boost::noncopyable$/;"	c	file:
+PipelineFactory	examples/filetransfer/loadtest/Client.java	/^        private PipelineFactory(int kMinLength, int kMaxLength, CountDownLatch latch) {$/;"	m	class:Client.PipelineFactory	file:
+PipelineFactory	examples/filetransfer/loadtest/Client.java	/^    private static final class PipelineFactory implements ChannelPipelineFactory {$/;"	c	class:Client
+PollFdList	muduo/net/poller/PollPoller.h	/^  typedef std::vector<struct pollfd> PollFdList;$/;"	t	class:muduo::net::PollPoller
+PollPoller	muduo/net/poller/PollPoller.cc	/^PollPoller::PollPoller(EventLoop* loop)$/;"	f	class:PollPoller
+PollPoller	muduo/net/poller/PollPoller.h	/^class PollPoller : public Poller$/;"	c	namespace:muduo::net
+Poller	muduo/net/Poller.cc	/^Poller::Poller(EventLoop* loop)$/;"	f	class:Poller
+Poller	muduo/net/Poller.h	/^class Poller : boost::noncopyable$/;"	c	namespace:muduo::net
+Printer	examples/asio/tutorial/timer4/timer.cc	/^  Printer(muduo::net::EventLoop* loop)$/;"	f	class:Printer
+Printer	examples/asio/tutorial/timer4/timer.cc	/^class Printer : boost::noncopyable$/;"	c	file:
+Printer	examples/asio/tutorial/timer5/timer.cc	/^  Printer(muduo::net::EventLoop* loop1, muduo::net::EventLoop* loop2)$/;"	f	class:Printer
+Printer	examples/asio/tutorial/timer5/timer.cc	/^class Printer : boost::noncopyable$/;"	c	file:
+Printer	examples/asio/tutorial/timer6/timer.cc	/^  Printer(muduo::net::EventLoop* loop1, muduo::net::EventLoop* loop2)$/;"	f	class:Printer
+Printer	examples/asio/tutorial/timer6/timer.cc	/^class Printer : boost::noncopyable$/;"	c	file:
+ProcessInfo	muduo/base/ProcessInfo.h	/^namespace ProcessInfo$/;"	n	namespace:muduo
+ProcessInspector	muduo/net/inspect/ProcessInspector.h	/^class ProcessInspector : boost::noncopyable$/;"	c	namespace:muduo::net
+ProtobufCodec	examples/protobuf/codec/codec.h	/^  ProtobufCodec(const ProtobufMessageCallback& messageCb, const ErrorCallback& errorCb)$/;"	f	class:ProtobufCodec
+ProtobufCodec	examples/protobuf/codec/codec.h	/^  explicit ProtobufCodec(const ProtobufMessageCallback& messageCb)$/;"	f	class:ProtobufCodec
+ProtobufCodec	examples/protobuf/codec/codec.h	/^class ProtobufCodec : boost::noncopyable$/;"	c
+ProtobufDispatcher	examples/protobuf/codec/dispatcher.h	/^  explicit ProtobufDispatcher(const ProtobufMessageCallback& defaultCb)$/;"	f	class:ProtobufDispatcher
+ProtobufDispatcher	examples/protobuf/codec/dispatcher.h	/^class ProtobufDispatcher$/;"	c
+ProtobufDispatcherLite	examples/protobuf/codec/dispatcher_lite.h	/^  explicit ProtobufDispatcherLite(const ProtobufMessageCallback& defaultCb)$/;"	f	class:ProtobufDispatcherLite
+ProtobufDispatcherLite	examples/protobuf/codec/dispatcher_lite.h	/^class ProtobufDispatcherLite : boost::noncopyable$/;"	c
+ProtobufMessageCallback	examples/protobuf/codec/codec.h	/^                                muduo::Timestamp)> ProtobufMessageCallback;$/;"	t	class:ProtobufCodec
+ProtobufMessageCallback	examples/protobuf/codec/dispatcher.h	/^                                muduo::Timestamp)> ProtobufMessageCallback;$/;"	t	class:ProtobufDispatcher
+ProtobufMessageCallback	examples/protobuf/codec/dispatcher_lite.h	/^                                muduo::Timestamp)> ProtobufMessageCallback;$/;"	t	class:ProtobufDispatcherLite
+ProtobufMessageCallback	muduo/net/protorpc/RpcCodec.h	/^                                Timestamp)> ProtobufMessageCallback;$/;"	t	class:muduo::net::RpcCodec
+ProtobufMessageTCallback	examples/protobuf/codec/dispatcher.h	/^                                muduo::Timestamp)> ProtobufMessageTCallback;$/;"	t	class:CallbackT
+ProtobufVersionCheck	muduo/net/protorpc/RpcCodec.cc	/^  int ProtobufVersionCheck()$/;"	f	namespace:__anon5
+Protocol	examples/memcached/server/Session.h	/^  enum Protocol$/;"	g	class:Session
+PubSubClient	examples/hub/pubsub.cc	/^PubSubClient::PubSubClient(EventLoop* loop,$/;"	f	class:PubSubClient
+PubSubClient	examples/hub/pubsub.h	/^class PubSubClient : boost::noncopyable$/;"	c	namespace:pubsub
+PubSubServer	examples/hub/hub.cc	/^  PubSubServer(muduo::net::EventLoop* loop,$/;"	f	class:pubsub::PubSubServer
+PubSubServer	examples/hub/hub.cc	/^class PubSubServer : boost::noncopyable$/;"	c	namespace:pubsub	file:
+QueryClient	examples/protobuf/codec/client.cc	/^  QueryClient(EventLoop* loop,$/;"	f	class:QueryClient
+QueryClient	examples/protobuf/codec/client.cc	/^class QueryClient : boost::noncopyable$/;"	c	file:
+QueryData	examples/cdns/Resolver.h	/^    QueryData(Resolver* o, const Callback& cb)$/;"	f	struct:cdns::Resolver::QueryData
+QueryData	examples/cdns/Resolver.h	/^  struct QueryData$/;"	s	class:cdns::Resolver
+QueryPtr	examples/protobuf/codec/dispatcher_test.cc	/^typedef boost::shared_ptr<muduo::Query> QueryPtr;$/;"	t	file:
+QueryPtr	examples/protobuf/codec/server.cc	/^typedef boost::shared_ptr<muduo::Query> QueryPtr;$/;"	t	file:
+QueryServer	examples/protobuf/codec/server.cc	/^  QueryServer(EventLoop* loop,$/;"	f	class:QueryServer
+QueryServer	examples/protobuf/codec/server.cc	/^class QueryServer : boost::noncopyable$/;"	c	file:
+ReadEventCallback	muduo/net/Channel.h	/^  typedef boost::function<void(Timestamp)> ReadEventCallback;$/;"	t	class:muduo::net::Channel
+Reader	examples/memcached/server/Session.cc	/^  Reader(Tokenizer::iterator& beg, Tokenizer::iterator end)$/;"	f	struct:Session::Reader
+Reader	examples/memcached/server/Session.cc	/^struct Session::Reader$/;"	s	class:Session	file:
+RecordHeader	examples/fastcgi/fastcgi.cc	/^struct FastCgiCodec::RecordHeader$/;"	s	class:FastCgiCodec	file:
+Request	examples/curl/Curl.cc	/^Request::Request(Curl* owner, StringPiece url)$/;"	f	class:Request
+Request	examples/curl/Curl.h	/^class Request : public boost::enable_shared_from_this<Request>,$/;"	c	namespace:curl
+RequestPtr	examples/curl/Curl.h	/^typedef boost::shared_ptr<Request> RequestPtr;$/;"	t	namespace:curl
+Resolve	examples/protobuf/resolver/server.cc	/^  virtual void Resolve(::google::protobuf::RpcController* controller,$/;"	f	class:resolver::ResolverServiceImpl
+Resolver	examples/cdns/Resolver.cc	/^Resolver::Resolver(EventLoop* loop, Option opt)$/;"	f	class:Resolver
+Resolver	examples/cdns/Resolver.h	/^class Resolver : boost::noncopyable$/;"	c	namespace:cdns
+ResolverServiceImpl	examples/protobuf/resolver/server.cc	/^  ResolverServiceImpl(EventLoop* loop)$/;"	f	class:resolver::ResolverServiceImpl
+ResolverServiceImpl	examples/protobuf/resolver/server.cc	/^class ResolverServiceImpl : public ResolverService$/;"	c	namespace:resolver	file:
+RpcChannel	muduo/net/protorpc/RpcChannel.cc	/^RpcChannel::RpcChannel()$/;"	f	class:RpcChannel
+RpcChannel	muduo/net/protorpc/RpcChannel.cc	/^RpcChannel::RpcChannel(const TcpConnectionPtr& conn)$/;"	f	class:RpcChannel
+RpcChannel	muduo/net/protorpc/RpcChannel.h	/^class RpcChannel : public ::google::protobuf::RpcChannel$/;"	c	namespace:muduo::net
+RpcChannelPtr	muduo/net/protorpc/RpcChannel.h	/^typedef boost::shared_ptr<RpcChannel> RpcChannelPtr;$/;"	t	namespace:muduo::net
+RpcClient	examples/protobuf/resolver/client.cc	/^  RpcClient(EventLoop* loop, const InetAddress& serverAddr)$/;"	f	class:RpcClient
+RpcClient	examples/protobuf/resolver/client.cc	/^class RpcClient : boost::noncopyable$/;"	c	file:
+RpcClient	examples/protobuf/rpc/client.cc	/^  RpcClient(EventLoop* loop, const InetAddress& serverAddr)$/;"	f	class:RpcClient
+RpcClient	examples/protobuf/rpc/client.cc	/^class RpcClient : boost::noncopyable$/;"	c	file:
+RpcClient	examples/protobuf/rpcbench/client.cc	/^  RpcClient(EventLoop* loop,$/;"	f	class:RpcClient
+RpcClient	examples/protobuf/rpcbench/client.cc	/^class RpcClient : boost::noncopyable$/;"	c	file:
+RpcCodec	muduo/net/protorpc/RpcCodec.h	/^  RpcCodec(const ProtobufMessageCallback& messageCb, const ErrorCallback& errorCb)$/;"	f	class:muduo::net::RpcCodec
+RpcCodec	muduo/net/protorpc/RpcCodec.h	/^  explicit RpcCodec(const ProtobufMessageCallback& messageCb)$/;"	f	class:muduo::net::RpcCodec
+RpcCodec	muduo/net/protorpc/RpcCodec.h	/^class RpcCodec$/;"	c	namespace:muduo::net
+RpcServer	muduo/net/protorpc/RpcServer.cc	/^RpcServer::RpcServer(EventLoop* loop,$/;"	f	class:RpcServer
+RpcServer	muduo/net/protorpc/RpcServer.h	/^class RpcServer$/;"	c	namespace:muduo::net
+SA	muduo/net/SocketsOps.cc	/^typedef struct sockaddr SA;$/;"	t	namespace:__anon1	typeref:struct:__anon1::sockaddr	file:
+STL	muduo/base/tests/SingletonThreadLocal_test.cc	30;"	d	file:
+STRINGPIECE_BINARY_PREDICATE	muduo/base/StringPiece.h	120;"	d
+STRINGPIECE_BINARY_PREDICATE	muduo/base/StringPiece.h	129;"	d
+SendThrottler	examples/wordcount/hasher.cc	/^  SendThrottler(EventLoop* loop, const InetAddress& addr)$/;"	f	class:SendThrottler
+SendThrottler	examples/wordcount/hasher.cc	/^class SendThrottler : boost::noncopyable$/;"	c	file:
+Session	examples/memcached/server/Session.h	/^  Session(MemcacheServer* owner, const muduo::net::TcpConnectionPtr& conn)$/;"	f	class:Session
+Session	examples/memcached/server/Session.h	/^class Session : boost::noncopyable,$/;"	c
+Session	examples/pingpong/client.cc	/^  Session(EventLoop* loop,$/;"	f	class:Session
+Session	examples/pingpong/client.cc	/^class Session : boost::noncopyable$/;"	c	file:
+SessionPtr	examples/memcached/server/Session.h	/^typedef boost::shared_ptr<Session> SessionPtr;$/;"	t
+Singleton	muduo/base/Singleton.h	/^class Singleton : boost::noncopyable$/;"	c	namespace:muduo
+SmallFile	muduo/base/FileUtil.cc	/^FileUtil::SmallFile::SmallFile(StringPiece filename)$/;"	f	class:FileUtil::SmallFile
+SmallFile	muduo/base/FileUtil.h	/^  class SmallFile : boost::noncopyable$/;"	c	namespace:muduo::FileUtil
+Socket	muduo/net/Socket.h	/^  explicit Socket(int sockfd)$/;"	f	class:muduo::net::Socket
+Socket	muduo/net/Socket.h	/^class Socket : boost::noncopyable$/;"	c	namespace:muduo::net
+Solve	examples/protobuf/rpc/server.cc	/^  virtual void Solve(::google::protobuf::RpcController* controller,$/;"	f	class:sudoku::SudokuServiceImpl
+SourceFile	muduo/base/Logging.h	/^    explicit SourceFile(const char* filename)$/;"	f	class:muduo::Logger::SourceFile
+SourceFile	muduo/base/Logging.h	/^    inline SourceFile(const char (&arr)[N])$/;"	f	class:muduo::Logger::SourceFile
+SourceFile	muduo/base/Logging.h	/^  class SourceFile$/;"	c	class:muduo::Logger
+SpaceSeparator	examples/memcached/server/Session.h	/^  struct SpaceSeparator$/;"	s	class:Session
+State	examples/memcached/server/Session.h	/^  enum State$/;"	g	class:Session
+StateE	muduo/net/TcpConnection.h	/^  enum StateE { kDisconnected, kConnecting, kConnected, kDisconnecting };$/;"	g	class:muduo::net::TcpConnection
+States	muduo/net/Connector.h	/^  enum States { kDisconnected, kConnecting, kConnected };$/;"	g	class:muduo::net::Connector
+Stats	examples/memcached/server/MemcacheServer.cc	/^struct MemcacheServer::Stats$/;"	s	class:MemcacheServer	file:
+StringMessageCallback	examples/asio/chat/codec.h	/^                                muduo::Timestamp)> StringMessageCallback;$/;"	t	class:LengthHeaderCodec
+StringPiece	muduo/base/StringPiece.h	/^  StringPiece()$/;"	f	class:muduo::StringPiece
+StringPiece	muduo/base/StringPiece.h	/^  StringPiece(const char* offset, int len)$/;"	f	class:muduo::StringPiece
+StringPiece	muduo/base/StringPiece.h	/^  StringPiece(const char* str)$/;"	f	class:muduo::StringPiece
+StringPiece	muduo/base/StringPiece.h	/^  StringPiece(const std::string& str)$/;"	f	class:muduo::StringPiece
+StringPiece	muduo/base/StringPiece.h	/^  StringPiece(const string& str)$/;"	f	class:muduo::StringPiece
+StringPiece	muduo/base/StringPiece.h	/^  StringPiece(const unsigned char* str)$/;"	f	class:muduo::StringPiece
+StringPiece	muduo/base/StringPiece.h	/^class StringPiece {$/;"	c	namespace:muduo
+SubscribeCallback	examples/hub/pubsub.h	/^                                Timestamp)> SubscribeCallback;$/;"	t	class:pubsub::PubSubClient
+SudokuClient	examples/sudoku/client.cc	/^  SudokuClient(EventLoop* loop,$/;"	f	class:SudokuClient
+SudokuClient	examples/sudoku/client.cc	/^class SudokuClient : boost::noncopyable$/;"	c	file:
+SudokuServer	examples/sudoku/server_basic.cc	/^  SudokuServer(EventLoop* loop, const InetAddress& listenAddr)$/;"	f	class:SudokuServer
+SudokuServer	examples/sudoku/server_basic.cc	/^class SudokuServer$/;"	c	file:
+SudokuServer	examples/sudoku/server_multiloop.cc	/^  SudokuServer(EventLoop* loop, const InetAddress& listenAddr, int numThreads)$/;"	f	class:SudokuServer
+SudokuServer	examples/sudoku/server_multiloop.cc	/^class SudokuServer$/;"	c	file:
+SudokuServer	examples/sudoku/server_threadpool.cc	/^  SudokuServer(EventLoop* loop, const InetAddress& listenAddr, int numThreads)$/;"	f	class:SudokuServer
+SudokuServer	examples/sudoku/server_threadpool.cc	/^class SudokuServer$/;"	c	file:
+SudokuServiceImpl	examples/protobuf/rpc/server.cc	/^class SudokuServiceImpl : public SudokuService$/;"	c	namespace:sudoku	file:
+SudokuSolver	examples/sudoku/sudoku.cc	/^    SudokuSolver(int board[kCells])$/;"	f	class:SudokuSolver
+SudokuSolver	examples/sudoku/sudoku.cc	/^class SudokuSolver$/;"	c	file:
+T	muduo/base/Logging.cc	/^  T(const char* str, unsigned len)$/;"	f	class:muduo::T
+T	muduo/base/Logging.cc	/^class T$/;"	c	namespace:muduo	file:
+TRACE	muduo/base/Logging.h	/^    TRACE,$/;"	e	enum:muduo::Logger::LogLevel
+Task	muduo/base/ThreadPool.h	/^  typedef boost::function<void ()> Task;$/;"	t	class:muduo::ThreadPool
+TcpClient	muduo/net/TcpClient.cc	/^TcpClient::TcpClient(EventLoop* loop,$/;"	f	class:TcpClient
+TcpClient	muduo/net/TcpClient.h	/^class TcpClient : boost::noncopyable$/;"	c	namespace:muduo::net
+TcpClientPtr	examples/multiplexer/demux.cc	/^typedef boost::shared_ptr<TcpClient> TcpClientPtr;$/;"	t	file:
+TcpConnection	muduo/net/TcpConnection.cc	/^TcpConnection::TcpConnection(EventLoop* loop,$/;"	f	class:TcpConnection
+TcpConnection	muduo/net/TcpConnection.h	/^class TcpConnection : boost::noncopyable,$/;"	c	namespace:muduo::net
+TcpConnectionPtr	muduo/net/Callbacks.h	/^typedef boost::shared_ptr<TcpConnection> TcpConnectionPtr;$/;"	t	namespace:muduo::net
+TcpConnectionPtr	muduo/net/TcpConnection.h	/^typedef boost::shared_ptr<TcpConnection> TcpConnectionPtr;$/;"	t	namespace:muduo::net
+TcpConnectionPtr	muduo/net/protorpc/RpcCodec.h	/^typedef boost::shared_ptr<TcpConnection> TcpConnectionPtr;$/;"	t	namespace:muduo::net
+TcpServer	muduo/net/TcpServer.cc	/^TcpServer::TcpServer(EventLoop* loop,$/;"	f	class:TcpServer
+TcpServer	muduo/net/TcpServer.h	/^class TcpServer : boost::noncopyable$/;"	c	namespace:muduo::net
+Test	muduo/base/tests/BlockingQueue_test.cc	/^  Test(int numThreads)$/;"	f	class:Test
+Test	muduo/base/tests/BlockingQueue_test.cc	/^class Test$/;"	c	file:
+Test	muduo/base/tests/BoundedBlockingQueue_test.cc	/^  Test(int numThreads)$/;"	f	class:Test
+Test	muduo/base/tests/BoundedBlockingQueue_test.cc	/^class Test$/;"	c	file:
+Test	muduo/base/tests/SingletonThreadLocal_test.cc	/^  Test()$/;"	f	class:Test
+Test	muduo/base/tests/SingletonThreadLocal_test.cc	/^class Test : boost::noncopyable$/;"	c	file:
+Test	muduo/base/tests/Singleton_test.cc	/^  Test()$/;"	f	class:Test
+Test	muduo/base/tests/Singleton_test.cc	/^class Test : boost::noncopyable$/;"	c	file:
+Test	muduo/base/tests/ThreadLocalSingleton_test.cc	/^  Test()$/;"	f	class:Test
+Test	muduo/base/tests/ThreadLocalSingleton_test.cc	/^class Test : boost::noncopyable$/;"	c	file:
+Test	muduo/base/tests/ThreadLocal_test.cc	/^  Test()$/;"	f	class:Test
+Test	muduo/base/tests/ThreadLocal_test.cc	/^class Test : boost::noncopyable$/;"	c	file:
+TestCase	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/TestCase.java	/^public abstract class TestCase {$/;"	c
+TestCase	muduo/base/tests/TimeZone_unittest.cc	/^struct TestCase$/;"	s	file:
+TestFailedException	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/TestFailedException.java	/^    public TestFailedException(String message) {$/;"	m	class:TestFailedException
+TestFailedException	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/TestFailedException.java	/^public class TestFailedException extends RuntimeException {$/;"	c
+TestOneClientBackendSend	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/testcase/TestOneClientBackendSend.java	/^public class TestOneClientBackendSend extends TestCase {$/;"	c
+TestOneClientBothSend	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/testcase/TestOneClientBothSend.java	/^public class TestOneClientBothSend extends TestCase {$/;"	c
+TestOneClientNoData	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/testcase/TestOneClientNoData.java	/^public class TestOneClientNoData extends TestCase {$/;"	c
+TestOneClientSend	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/testcase/TestOneClientSend.java	/^public class TestOneClientSend extends TestCase {$/;"	c
+TestTwoClients	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/testcase/TestTwoClients.java	/^public class TestTwoClients extends TestCase {$/;"	c
+Thread	muduo/base/Thread.cc	/^Thread::Thread(ThreadFunc&& func, const string& n)$/;"	f	class:Thread
+Thread	muduo/base/Thread.cc	/^Thread::Thread(const ThreadFunc& func, const string& n)$/;"	f	class:Thread
+Thread	muduo/base/Thread.h	/^class Thread : boost::noncopyable$/;"	c	namespace:muduo
+ThreadData	muduo/base/Thread.cc	/^  ThreadData(const ThreadFunc& func,$/;"	f	struct:muduo::detail::ThreadData
+ThreadData	muduo/base/Thread.cc	/^struct ThreadData$/;"	s	namespace:muduo::detail	file:
+ThreadFunc	muduo/base/Thread.cc	/^  typedef muduo::Thread::ThreadFunc ThreadFunc;$/;"	t	struct:muduo::detail::ThreadData	file:
+ThreadFunc	muduo/base/Thread.h	/^  typedef boost::function<void ()> ThreadFunc;$/;"	t	class:muduo::Thread
+ThreadInitCallback	muduo/net/EventLoopThread.h	/^  typedef boost::function<void(EventLoop*)> ThreadInitCallback;$/;"	t	class:muduo::net::EventLoopThread
+ThreadInitCallback	muduo/net/EventLoopThreadPool.h	/^  typedef boost::function<void(EventLoop*)> ThreadInitCallback;$/;"	t	class:muduo::net::EventLoopThreadPool
+ThreadInitCallback	muduo/net/TcpServer.h	/^  typedef boost::function<void(EventLoop*)> ThreadInitCallback;$/;"	t	class:muduo::net::TcpServer
+ThreadLocal	muduo/base/ThreadLocal.h	/^  ThreadLocal()$/;"	f	class:muduo::ThreadLocal
+ThreadLocal	muduo/base/ThreadLocal.h	/^class ThreadLocal : boost::noncopyable$/;"	c	namespace:muduo
+ThreadLocalSingleton	muduo/base/ThreadLocalSingleton.h	/^class ThreadLocalSingleton : boost::noncopyable$/;"	c	namespace:muduo
+ThreadNameInitializer	muduo/base/Thread.cc	/^  ThreadNameInitializer()$/;"	f	class:muduo::detail::ThreadNameInitializer
+ThreadNameInitializer	muduo/base/Thread.cc	/^class ThreadNameInitializer$/;"	c	namespace:muduo::detail	file:
+ThreadPool	muduo/base/ThreadPool.cc	/^ThreadPool::ThreadPool(const string& name)$/;"	f	class:ThreadPool
+ThreadPool	muduo/base/ThreadPool.h	/^class ThreadPool : boost::noncopyable$/;"	c	namespace:muduo
+TimeClient	examples/simple/timeclient/timeclient.cc	/^  TimeClient(EventLoop* loop, const InetAddress& serverAddr)$/;"	f	class:TimeClient
+TimeClient	examples/simple/timeclient/timeclient.cc	/^class TimeClient : boost::noncopyable$/;"	c	file:
+TimeServer	examples/simple/time/time.cc	/^TimeServer::TimeServer(muduo::net::EventLoop* loop,$/;"	f	class:TimeServer
+TimeServer	examples/simple/time/time.h	/^class TimeServer$/;"	c
+TimeZone	muduo/base/TimeZone.cc	/^TimeZone::TimeZone(const char* zonefile)$/;"	f	class:TimeZone
+TimeZone	muduo/base/TimeZone.h	/^class TimeZone : public muduo::copyable$/;"	c	namespace:muduo
+Timer	muduo/net/Timer.h	/^  Timer(TimerCallback&& cb, Timestamp when, double interval)$/;"	f	class:muduo::net::Timer
+Timer	muduo/net/Timer.h	/^  Timer(const TimerCallback& cb, Timestamp when, double interval)$/;"	f	class:muduo::net::Timer
+Timer	muduo/net/Timer.h	/^class Timer : boost::noncopyable$/;"	c	namespace:muduo::net
+TimerCallback	muduo/net/Callbacks.h	/^typedef boost::function<void()> TimerCallback;$/;"	t	namespace:muduo::net
+TimerId	muduo/net/TimerId.h	/^  TimerId()$/;"	f	class:muduo::net::TimerId
+TimerId	muduo/net/TimerId.h	/^  TimerId(Timer* timer, int64_t seq)$/;"	f	class:muduo::net::TimerId
+TimerId	muduo/net/TimerId.h	/^class TimerId : public muduo::copyable$/;"	c	namespace:muduo::net
+TimerList	muduo/net/TimerQueue.h	/^  typedef std::set<Entry> TimerList;$/;"	t	class:muduo::net::TimerQueue
+TimerQueue	muduo/net/TimerQueue.cc	/^TimerQueue::TimerQueue(EventLoop* loop)$/;"	f	class:TimerQueue
+TimerQueue	muduo/net/TimerQueue.h	/^class TimerQueue : boost::noncopyable$/;"	c	namespace:muduo::net
+Timestamp	muduo/base/Timestamp.cc	/^Timestamp::Timestamp(int64_t microseconds)$/;"	f	class:Timestamp
+Timestamp	muduo/base/Timestamp.h	/^  Timestamp()$/;"	f	class:muduo::Timestamp
+Timestamp	muduo/base/Timestamp.h	/^class Timestamp : public muduo::copyable,$/;"	c	namespace:muduo
+Tokenizer	examples/memcached/server/Session.h	/^      muduo::StringPiece> Tokenizer;$/;"	t	class:Session
+Topic	examples/hub/hub.cc	/^  Topic(const string& topic)$/;"	f	class:pubsub::Topic
+Topic	examples/hub/hub.cc	/^class Topic : public muduo::copyable$/;"	c	namespace:pubsub	file:
+Transition	muduo/base/TimeZone.cc	/^  Transition(time_t t, time_t l, int localIdx)$/;"	f	struct:muduo::detail::Transition
+Transition	muduo/base/TimeZone.cc	/^struct Transition$/;"	s	namespace:muduo::detail	file:
+Tunnel	examples/socks4a/tunnel.h	/^  Tunnel(muduo::net::EventLoop* loop,$/;"	f	class:Tunnel
+Tunnel	examples/socks4a/tunnel.h	/^class Tunnel : public boost::enable_shared_from_this<Tunnel>,$/;"	c
+TunnelPtr	examples/socks4a/tunnel.h	/^typedef boost::shared_ptr<Tunnel> TunnelPtr;$/;"	t
+UnassignGuard	muduo/base/Mutex.h	/^    UnassignGuard(MutexLock& owner)$/;"	f	class:muduo::MutexLock::UnassignGuard
+UnassignGuard	muduo/base/Mutex.h	/^  class UnassignGuard : boost::noncopyable$/;"	c	class:muduo::MutexLock
+UpdatePolicy	examples/memcached/server/Item.h	/^  enum UpdatePolicy$/;"	g	class:Item
+UptimeClient	examples/netty/uptime/uptime.cc	/^  UptimeClient(EventLoop* loop, const InetAddress& listenAddr)$/;"	f	class:UptimeClient
+UptimeClient	examples/netty/uptime/uptime.cc	/^class UptimeClient : boost::noncopyable$/;"	c	file:
+UserMap	examples/twisted/finger/finger06.cc	/^typedef std::map<string, string> UserMap;$/;"	t	file:
+UserMap	examples/twisted/finger/finger07.cc	/^typedef std::map<string, string> UserMap;$/;"	t	file:
+Version	muduo/net/http/HttpRequest.h	/^  enum Version$/;"	g	class:muduo::net::HttpRequest
+WARN	muduo/base/Logging.h	/^    WARN,$/;"	e	enum:muduo::Logger::LogLevel
+WeakConnectionList	examples/idleconnection/echo.h	/^  typedef boost::circular_buffer<Bucket> WeakConnectionList;$/;"	t	class:EchoServer
+WeakConnectionList	examples/idleconnection/sortedlist.cc	/^  typedef std::list<WeakTcpConnectionPtr> WeakConnectionList;$/;"	t	class:EchoServer	file:
+WeakEntryPtr	examples/idleconnection/echo.h	/^  typedef boost::weak_ptr<Entry> WeakEntryPtr;$/;"	t	class:EchoServer
+WeakTcpConnectionPtr	examples/idleconnection/echo.h	/^  typedef boost::weak_ptr<muduo::net::TcpConnection> WeakTcpConnectionPtr;$/;"	t	class:EchoServer
+WeakTcpConnectionPtr	examples/idleconnection/sortedlist.cc	/^  typedef boost::weak_ptr<TcpConnection> WeakTcpConnectionPtr;$/;"	t	class:EchoServer	file:
+WordCountMap	examples/wordcount/hash.h	/^typedef boost::unordered_map<muduo::string, int64_t> WordCountMap;$/;"	t
+WordCountReceiver	examples/wordcount/receiver.cc	/^  WordCountReceiver(EventLoop* loop, const InetAddress& listenAddr)$/;"	f	class:WordCountReceiver
+WordCountReceiver	examples/wordcount/receiver.cc	/^class WordCountReceiver : boost::noncopyable$/;"	c	file:
+WordCountSender	examples/wordcount/hasher.cc	/^WordCountSender::WordCountSender(const std::string& receivers)$/;"	f	class:WordCountSender
+WordCountSender	examples/wordcount/hasher.cc	/^class WordCountSender : boost::noncopyable$/;"	c	file:
+WriteCompleteCallback	muduo/net/Callbacks.h	/^typedef boost::function<void (const TcpConnectionPtr&)> WriteCompleteCallback;$/;"	t	namespace:muduo::net
+YearMonthDay	muduo/base/Date.h	/^  struct YearMonthDay$/;"	s	class:muduo::Date
+__STDC_FORMAT_MACROS	examples/wordcount/hasher.cc	17;"	d	file:
+__STDC_FORMAT_MACROS	muduo/base/Timestamp.cc	5;"	d	file:
+__STDC_FORMAT_MACROS	muduo/base/Timestamp.cc	7;"	d	file:
+__STDC_FORMAT_MACROS	muduo/base/tests/FileUtil_test.cc	4;"	d	file:
+__STDC_FORMAT_MACROS	muduo/base/tests/LogStream_bench.cc	6;"	d	file:
+__STDC_FORMAT_MACROS	muduo/base/tests/ProcessInfo_test.cc	3;"	d	file:
+__STDC_LIMIT_MACROS	muduo/net/TimerQueue.cc	9;"	d	file:
+__type_traits	muduo/base/StringPiece.h	/^template<> struct __type_traits<muduo::StringPiece> {$/;"	s
+abbreviation	muduo/base/TimeZone.cc	/^  string abbreviation;$/;"	m	struct:TimeZone::Data	file:
+abortNotInLoopThread	muduo/net/EventLoop.cc	/^void EventLoop::abortNotInLoopThread()$/;"	f	class:EventLoop
+accept	muduo/net/Socket.cc	/^int Socket::accept(InetAddress* peeraddr)$/;"	f	class:Socket
+accept	muduo/net/SocketsOps.cc	/^int sockets::accept(int sockfd, struct sockaddr_in* addr)$/;"	f	class:sockets
+acceptChannel_	muduo/net/Acceptor.h	/^  Channel acceptChannel_;$/;"	m	class:muduo::net::Acceptor
+acceptRanges_	examples/curl/download.cc	/^  bool acceptRanges_;$/;"	m	class:Downloader	file:
+acceptSocket_	muduo/net/Acceptor.h	/^  Socket acceptSocket_;$/;"	m	class:muduo::net::Acceptor
+acceptor_	muduo/net/TcpServer.h	/^  boost::scoped_ptr<Acceptor> acceptor_; \/\/ avoid revealing Acceptor$/;"	m	class:muduo::net::TcpServer
+acked_	examples/memcached/client/bench.cc	/^  int acked_;$/;"	m	class:Client	file:
+activeChannels_	muduo/net/EventLoop.h	/^  ChannelList activeChannels_;$/;"	m	class:muduo::net::EventLoop
+activeTimers_	muduo/net/TimerQueue.h	/^  ActiveTimerSet activeTimers_;$/;"	m	class:muduo::net::TimerQueue
+add	examples/hub/hub.cc	/^  void add(const TcpConnectionPtr& conn)$/;"	f	class:pubsub::Topic
+add	muduo/base/Atomic.h	/^  void add(T x)$/;"	f	class:muduo::detail::AtomicIntegerT
+add	muduo/base/LogStream.h	/^  void add(size_t len) { cur_ += len; }$/;"	f	class:muduo::detail::FixedBuffer
+add	muduo/net/inspect/Inspector.cc	/^void Inspector::add(const string& module,$/;"	f	class:Inspector
+addAndGet	muduo/base/Atomic.h	/^  T addAndGet(T x)$/;"	f	class:muduo::detail::AtomicIntegerT
+addHeader	muduo/net/http/HttpRequest.h	/^  void addHeader(const char* start, const char* colon, const char* end)$/;"	f	class:muduo::net::HttpRequest
+addHeader	muduo/net/http/HttpResponse.h	/^  void addHeader(const string& key, const string& value)$/;"	f	class:muduo::net::HttpResponse
+addTestCase	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/MultiplexerTest.java	/^    private void addTestCase(TestCase testCase) {$/;"	m	class:MultiplexerTest	file:
+addTime	muduo/base/Timestamp.h	/^inline Timestamp addTime(Timestamp timestamp, double seconds)$/;"	f	namespace:muduo
+addTimer	muduo/net/TimerQueue.cc	/^TimerId TimerQueue::addTimer(TimerCallback&& cb,$/;"	f	class:TimerQueue
+addTimer	muduo/net/TimerQueue.cc	/^TimerId TimerQueue::addTimer(const TimerCallback& cb,$/;"	f	class:TimerQueue
+addTimerInLoop	muduo/net/TimerQueue.cc	/^void TimerQueue::addTimerInLoop(Timer* timer)$/;"	f	class:TimerQueue
+addr_	muduo/net/InetAddress.h	/^  struct sockaddr_in addr_;$/;"	m	class:muduo::net::InetAddress	typeref:struct:muduo::net::InetAddress::sockaddr_in
+afterFork	muduo/base/Thread.cc	/^void afterFork()$/;"	f	namespace:muduo::detail
+allConnected_	examples/protobuf/rpcbench/client.cc	/^  CountDownLatch* allConnected_;$/;"	m	class:RpcClient	file:
+allFinished_	examples/protobuf/rpcbench/client.cc	/^  CountDownLatch* allFinished_;$/;"	m	class:RpcClient	file:
+alphabet	examples/wordcount/gen.py	/^alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-'$/;"	v
+append	examples/memcached/server/Item.cc	/^void Item::append(const char* data, size_t len)$/;"	f	class:Item
+append	muduo/base/AsyncLogging.cc	/^void AsyncLogging::append(const char* logline, int len)$/;"	f	class:AsyncLogging
+append	muduo/base/LogFile.cc	/^  void append(const char* logline, const size_t len)$/;"	f	class:LogFile::File
+append	muduo/base/LogFile.cc	/^void LogFile::append(const char* logline, int len)$/;"	f	class:LogFile
+append	muduo/base/LogStream.h	/^  void append(const char* \/*restrict*\/ buf, size_t len)$/;"	f	class:muduo::detail::FixedBuffer
+append	muduo/base/LogStream.h	/^  void append(const char* data, int len) { buffer_.append(data, len); }$/;"	f	class:muduo::LogStream
+append	muduo/net/Buffer.h	/^  void append(const StringPiece& str)$/;"	f	class:muduo::net::Buffer
+append	muduo/net/Buffer.h	/^  void append(const char* \/*restrict*\/ data, size_t len)$/;"	f	class:muduo::net::Buffer
+append	muduo/net/Buffer.h	/^  void append(const void* \/*restrict*\/ data, size_t len)$/;"	f	class:muduo::net::Buffer
+appendInt16	muduo/net/Buffer.h	/^  void appendInt16(int16_t x)$/;"	f	class:muduo::net::Buffer
+appendInt32	muduo/net/Buffer.h	/^  void appendInt32(int32_t x)$/;"	f	class:muduo::net::Buffer
+appendInt8	muduo/net/Buffer.h	/^  void appendInt8(int8_t x)$/;"	f	class:muduo::net::Buffer
+appendToBuffer	muduo/net/http/HttpResponse.cc	/^void HttpResponse::appendToBuffer(Buffer* output) const$/;"	f	class:HttpResponse
+append_column	examples/sudoku/sudoku.cc	/^    void append_column(int n)$/;"	f	class:SudokuSolver	file:
+append_unlocked	muduo/base/LogFile.cc	/^void LogFile::append_unlocked(const char* logline, int len)$/;"	f	class:LogFile
+ares_channel	examples/cdns/Resolver.h	/^  typedef struct ares_channeldata* ares_channel;$/;"	t	typeref:struct:ares_channeldata
+ares_host_callback	examples/cdns/Resolver.cc	/^void Resolver::ares_host_callback(void* data, int status, int timeouts, struct hostent* hostent)$/;"	f	class:Resolver
+ares_sock_create_callback	examples/cdns/Resolver.cc	/^int Resolver::ares_sock_create_callback(int sockfd, int type, void* data)$/;"	f	class:Resolver
+ares_sock_state_callback	examples/cdns/Resolver.cc	/^void Resolver::ares_sock_state_callback(void* data, int sockfd, int read, int write)$/;"	f	class:Resolver
+arr	examples/wordcount/gen.py	/^	arr = [random.choice(alphabet) for i in range(word_len)]$/;"	v
+arrbIdx	muduo/base/TimeZone.cc	/^  int arrbIdx;$/;"	m	struct:muduo::detail::Localtime	file:
+asInt32	examples/protobuf/codec/codec.cc	/^int32_t asInt32(const char* buf)$/;"	f
+asInt32	muduo/net/protorpc/RpcCodec.cc	/^int32_t RpcCodec::asInt32(const char* buf)$/;"	f	class:RpcCodec
+asString	muduo/base/LogStream.h	/^  string asString() const { return string(data_, length()); }$/;"	f	class:muduo::detail::FixedBuffer
+as_string	muduo/base/StringPiece.h	/^  string as_string() const {$/;"	f	class:muduo::StringPiece
+assertEquals	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/TestCase.java	/^    protected void assertEquals(Object expected, Object actual) {$/;"	m	class:TestCase
+assertInLoopThread	muduo/net/EventLoop.h	/^  void assertInLoopThread()$/;"	f	class:muduo::net::EventLoop
+assertInLoopThread	muduo/net/Poller.h	/^  void assertInLoopThread()$/;"	f	class:muduo::net::Poller
+assertLocked	muduo/base/Mutex.h	/^  void assertLocked() const$/;"	f	class:muduo::MutexLock
+assertTrue	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/TestCase.java	/^    protected void assertTrue(boolean yes) {$/;"	m	class:TestCase
+assignHolder	muduo/base/Mutex.h	/^  void assignHolder()$/;"	f	class:muduo::MutexLock
+asyncOutput	muduo/base/tests/AsyncLogging_test.cc	/^void asyncOutput(const char* msg, int len)$/;"	f
+audiences_	examples/hub/hub.cc	/^  std::set<TcpConnectionPtr> audiences_;$/;"	m	class:pubsub::Topic	file:
+avail	muduo/base/LogStream.h	/^  int avail() const { return static_cast<int>(end() - cur_); }$/;"	f	class:muduo::detail::FixedBuffer
+availIds_	examples/multiplexer/multiplexer.cc	/^  std::queue<int> availIds_;$/;"	m	class:MultiplexServer	file:
+availIds_	examples/multiplexer/multiplexer_simple.cc	/^  std::queue<int> availIds_;$/;"	m	class:MultiplexServer	file:
+awaitUninterruptibly	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/MyCountDownLatch.java	/^    public void awaitUninterruptibly() {$/;"	m	class:MyCountDownLatch
+awaitUninterruptibly	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/MyCountDownLatch.java	/^    public void awaitUninterruptibly(int millis) {$/;"	m	class:MyCountDownLatch
+backend	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/MultiplexerTest.java	/^    private MockBackendServer backend;$/;"	f	class:MultiplexerTest	file:
+backend	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/TestCase.java	/^    protected MockBackendServer backend;$/;"	f	class:TestCase
+backendConn_	examples/multiplexer/multiplexer.cc	/^  TcpConnectionPtr backendConn_;$/;"	m	class:MultiplexServer	file:
+backendConn_	examples/multiplexer/multiplexer_simple.cc	/^  TcpConnectionPtr backendConn_;$/;"	m	class:MultiplexServer	file:
+backendIp	examples/multiplexer/multiplexer.cc	/^const char* backendIp = "127.0.0.1";$/;"	v
+backendIp	examples/multiplexer/multiplexer_simple.cc	/^const char* backendIp = "127.0.0.1";$/;"	v
+backend_	examples/multiplexer/multiplexer.cc	/^  TcpClient backend_;$/;"	m	class:MultiplexServer	file:
+backend_	examples/multiplexer/multiplexer_simple.cc	/^  TcpClient backend_;$/;"	m	class:MultiplexServer	file:
+baseLoop_	muduo/net/EventLoopThreadPool.h	/^  EventLoop* baseLoop_;$/;"	m	class:muduo::net::EventLoopThreadPool
+basename_	muduo/base/AsyncLogging.h	/^  string basename_;$/;"	m	class:muduo::AsyncLogging
+basename_	muduo/base/LogFile.h	/^  const string basename_;$/;"	m	class:muduo::LogFile
+basename_	muduo/base/Logging.h	/^  SourceFile basename_;$/;"	m	class:muduo::Logger::Impl
+begin	muduo/base/StringPiece.h	/^  const char* begin() const { return ptr_; }$/;"	f	class:muduo::StringPiece
+begin	muduo/net/Buffer.h	/^  char* begin()$/;"	f	class:muduo::net::Buffer
+begin	muduo/net/Buffer.h	/^  const char* begin() const$/;"	f	class:muduo::net::Buffer
+beginWrite	muduo/net/Buffer.h	/^  char* beginWrite()$/;"	f	class:muduo::net::Buffer
+beginWrite	muduo/net/Buffer.h	/^  const char* beginWrite() const$/;"	f	class:muduo::net::Buffer
+bench	muduo/base/tests/AsyncLogging_test.cc	/^void bench(bool longLog)$/;"	f
+bench	muduo/base/tests/Logging_test.cc	/^void bench(const char* type)$/;"	f
+benchLogStream	muduo/base/tests/LogStream_bench.cc	/^void benchLogStream()$/;"	f
+benchPrintf	muduo/base/tests/LogStream_bench.cc	/^void benchPrintf(const char* fmt)$/;"	f
+benchStringStream	muduo/base/tests/LogStream_bench.cc	/^void benchStringStream()$/;"	f
+benchmark	examples/shorturl/shorturl.cc	/^bool benchmark = false;$/;"	v
+benchmark	muduo/base/tests/Timestamp_unittest.cc	/^void benchmark()$/;"	f
+benchmark	muduo/net/http/tests/HttpServer_test.cc	/^bool benchmark = false;$/;"	v
+bindAddress	muduo/net/Socket.cc	/^void Socket::bindAddress(const InetAddress& addr)$/;"	f	class:Socket
+bindOrDie	muduo/net/SocketsOps.cc	/^void sockets::bindOrDie(int sockfd, const struct sockaddr_in& addr)$/;"	f	class:sockets
+body_	muduo/net/http/HttpResponse.h	/^  string body_;$/;"	m	class:muduo::net::HttpResponse
+boost	examples/idleconnection/echo.h	/^namespace boost$/;"	n
+boost	examples/wordcount/hash.h	/^namespace boost$/;"	n
+bootstrap	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/MockClient.java	/^    private ClientBootstrap bootstrap;$/;"	f	class:MockClient	file:
+boss	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/MockBackendServer.java	/^    private final Executor boss;$/;"	f	class:MockBackendServer	file:
+boss	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/MockClient.java	/^    private final Executor boss;$/;"	f	class:MockClient	file:
+boss	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/MultiplexerTest.java	/^    private final ExecutorService boss;$/;"	f	class:MultiplexerTest	file:
+bps	examples/wordcount/slowsink.py	/^bps = mps * 1000000$/;"	v
+buckets_	examples/wordcount/hasher.cc	/^  boost::ptr_vector<SendThrottler> buckets_;$/;"	m	class:WordCountSender	file:
+buf_	muduo/base/FileUtil.h	/^    char buf_[kBufferSize];$/;"	m	class:muduo::FileUtil::SmallFile
+buf_	muduo/base/LogStream.h	/^  char buf_[32];$/;"	m	class:muduo::Fmt
+buffer	muduo/base/FileUtil.h	/^    const char* buffer() const { return buf_; }$/;"	f	class:muduo::FileUtil::SmallFile
+buffer	muduo/base/LogStream.h	/^  const Buffer& buffer() const { return buffer_; }$/;"	f	class:muduo::LogStream
+bufferFactory	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/MultiplexerTest.java	/^    public static final ChannelBufferFactory bufferFactory =$/;"	f	class:MultiplexerTest
+bufferFactory	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/TestCase.java	/^    protected static final ChannelBufferFactory bufferFactory = MultiplexerTest.bufferFactory;$/;"	f	class:TestCase
+buffer_	examples/wordcount/hasher.cc	/^  Buffer buffer_;$/;"	m	class:SendThrottler	file:
+buffer_	muduo/base/LogFile.cc	/^  char buffer_[64*1024];$/;"	m	class:LogFile::File	file:
+buffer_	muduo/base/LogStream.h	/^  Buffer buffer_;$/;"	m	class:muduo::LogStream
+buffer_	muduo/net/Buffer.h	/^  std::vector<char> buffer_;$/;"	m	class:muduo::net::Buffer
+buffers_	muduo/base/AsyncLogging.h	/^  BufferVector buffers_;$/;"	m	class:muduo::AsyncLogging
+bytesRead	examples/pingpong/client.cc	/^  int64_t bytesRead() const$/;"	f	class:Session
+bytesRead_	examples/memcached/server/Session.h	/^  size_t bytesRead_;$/;"	m	class:Session
+bytesRead_	examples/pingpong/client.cc	/^  int64_t bytesRead_;$/;"	m	class:Session	file:
+bytesToDiscard_	examples/memcached/server/Session.h	/^  size_t bytesToDiscard_;$/;"	m	class:Session
+bytesWritten_	examples/pingpong/client.cc	/^  int64_t bytesWritten_;$/;"	m	class:Session	file:
+bzero	muduo/base/LogStream.h	/^  void bzero() { ::bzero(data_, sizeof data_); }$/;"	f	class:muduo::detail::FixedBuffer
+cacheTid	muduo/base/Thread.cc	/^void CurrentThread::cacheTid()$/;"	f	class:CurrentThread
+callback	examples/cdns/Resolver.h	/^    Callback callback;$/;"	m	struct:cdns::Resolver::QueryData
+callback	muduo/net/tests/EventLoop_unittest.cc	/^void callback()$/;"	f
+callback_	examples/protobuf/codec/dispatcher.h	/^  ProtobufMessageTCallback callback_;$/;"	m	class:CallbackT
+callback_	muduo/net/EventLoopThread.h	/^  ThreadInitCallback callback_;$/;"	m	class:muduo::net::EventLoopThread
+callback_	muduo/net/Timer.h	/^  const TimerCallback callback_;$/;"	m	class:muduo::net::Timer
+callbacks_	examples/protobuf/codec/dispatcher.h	/^  CallbackMap callbacks_;$/;"	m	class:ProtobufDispatcher
+callbacks_	examples/protobuf/codec/dispatcher_lite.h	/^  CallbackMap callbacks_;$/;"	m	class:ProtobufDispatcherLite
+callingExpiredTimers_	muduo/net/TimerQueue.h	/^  bool callingExpiredTimers_; \/* atomic *\/$/;"	m	class:muduo::net::TimerQueue
+callingPendingFunctors_	muduo/net/EventLoop.h	/^  bool callingPendingFunctors_; \/* atomic *\/$/;"	m	class:muduo::net::EventLoop
+cancel	muduo/net/EventLoop.cc	/^void EventLoop::cancel(TimerId timerId)$/;"	f	class:EventLoop
+cancel	muduo/net/TimerQueue.cc	/^void TimerQueue::cancel(TimerId timerId)$/;"	f	class:TimerQueue
+cancel	muduo/net/tests/TimerQueue_unittest.cc	/^void cancel(TimerId timer)$/;"	f
+cancelInLoop	muduo/net/TimerQueue.cc	/^void TimerQueue::cancelInLoop(TimerId timerId)$/;"	f	class:TimerQueue
+cancelingTimers_	muduo/net/TimerQueue.h	/^  ActiveTimerSet cancelingTimers_;$/;"	m	class:muduo::net::TimerQueue
+capacity	muduo/base/BoundedBlockingQueue.h	/^  size_t capacity() const$/;"	f	class:muduo::BoundedBlockingQueue
+cas	examples/memcached/server/Item.h	/^  uint64_t cas() const$/;"	f	class:Item
+cas_	examples/memcached/server/Item.h	/^  uint64_t       cas_;$/;"	m	class:Item
+cb_	examples/fastcgi/fastcgi.h	/^  Callback cb_;$/;"	m	class:FastCgiCodec
+cb_	examples/sudoku/client.cc	/^  DoneCallback cb_;$/;"	m	class:SudokuClient	file:
+cdns	examples/cdns/Resolver.h	/^namespace cdns$/;"	n
+channelConnected	examples/filetransfer/loadtest/Handler.java	/^    public void channelConnected(ChannelHandlerContext ctx, ChannelStateEvent e)$/;"	m	class:Handler
+channelConnected	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/MockBackendServer.java	/^        public void channelConnected(ChannelHandlerContext ctx, ChannelStateEvent e)$/;"	m	class:MockBackendServer.Handler
+channelConnected	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/MockClient.java	/^        public void channelConnected(ChannelHandlerContext ctx, ChannelStateEvent e)$/;"	m	class:MockClient.Handler
+channelDisconnected	examples/filetransfer/loadtest/Handler.java	/^    public void channelDisconnected(ChannelHandlerContext ctx, ChannelStateEvent e)$/;"	m	class:Handler
+channelDisconnected	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/MockBackendServer.java	/^        public void channelDisconnected(ChannelHandlerContext ctx, ChannelStateEvent e)$/;"	m	class:MockBackendServer.Handler
+channelDisconnected	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/MockClient.java	/^        public void channelDisconnected(ChannelHandlerContext ctx, ChannelStateEvent e)$/;"	m	class:MockClient.Handler
+channel_	examples/curl/Curl.h	/^  boost::shared_ptr<muduo::net::Channel> channel_;$/;"	m	class:curl::Request
+channel_	examples/protobuf/resolver/client.cc	/^  RpcChannelPtr channel_;$/;"	m	class:RpcClient	file:
+channel_	examples/protobuf/rpc/client.cc	/^  RpcChannelPtr channel_;$/;"	m	class:RpcClient	file:
+channel_	examples/protobuf/rpcbench/client.cc	/^  RpcChannelPtr channel_;$/;"	m	class:RpcClient	file:
+channel_	muduo/net/Connector.h	/^  boost::scoped_ptr<Channel> channel_;$/;"	m	class:muduo::net::Connector
+channel_	muduo/net/TcpConnection.h	/^  boost::scoped_ptr<Channel> channel_;$/;"	m	class:muduo::net::TcpConnection
+channels_	examples/cdns/Resolver.h	/^  ChannelList channels_;$/;"	m	class:cdns::Resolver
+channels_	muduo/net/poller/EPollPoller.h	/^  ChannelMap channels_;$/;"	m	class:muduo::net::EPollPoller
+channels_	muduo/net/poller/PollPoller.h	/^  ChannelMap channels_;$/;"	m	class:muduo::net::PollPoller
+checkFinish	examples/curl/Curl.cc	/^void Curl::checkFinish()$/;"	f	class:Curl
+clear	muduo/base/StringPiece.h	/^  void clear() { ptr_ = NULL; length_ = 0; }$/;"	f	class:muduo::StringPiece
+client	examples/multiplexer/demux.cc	/^  TcpClientPtr client;$/;"	m	struct:Entry	file:
+clientConnection	examples/roundtrip/roundtrip.cc	/^TcpConnectionPtr clientConnection;$/;"	v
+clientConnectionCallback	examples/roundtrip/roundtrip.cc	/^void clientConnectionCallback(const TcpConnectionPtr& conn)$/;"	f
+clientConns_	examples/multiplexer/multiplexer.cc	/^  std::map<int, TcpConnectionPtr> clientConns_;$/;"	m	class:MultiplexServer	file:
+clientConns_	examples/multiplexer/multiplexer_simple.cc	/^  std::map<int, TcpConnectionPtr> clientConns_;$/;"	m	class:MultiplexServer	file:
+clientMessageCallback	examples/roundtrip/roundtrip.cc	/^void clientMessageCallback(const TcpConnectionPtr&,$/;"	f
+clientReadCallback	examples/roundtrip/roundtrip_udp.cc	/^void clientReadCallback(int sockfd, muduo::Timestamp receiveTime)$/;"	f
+client_	examples/asio/chat/client.cc	/^  TcpClient client_;$/;"	m	class:ChatClient	file:
+client_	examples/asio/chat/loadtest.cc	/^  TcpClient client_;$/;"	m	class:ChatClient	file:
+client_	examples/hub/pubsub.h	/^  muduo::net::TcpClient client_;$/;"	m	class:pubsub::PubSubClient
+client_	examples/memcached/client/bench.cc	/^  TcpClient client_;$/;"	m	class:Client	file:
+client_	examples/netty/discard/client.cc	/^  TcpClient client_;$/;"	m	class:DiscardClient	file:
+client_	examples/netty/echo/client.cc	/^  TcpClient client_;$/;"	m	class:EchoClient	file:
+client_	examples/netty/uptime/uptime.cc	/^  TcpClient client_;$/;"	m	class:UptimeClient	file:
+client_	examples/pingpong/client.cc	/^  TcpClient client_;$/;"	m	class:Session	file:
+client_	examples/protobuf/codec/client.cc	/^  TcpClient client_;$/;"	m	class:QueryClient	file:
+client_	examples/protobuf/resolver/client.cc	/^  TcpClient client_;$/;"	m	class:RpcClient	file:
+client_	examples/protobuf/rpc/client.cc	/^  TcpClient client_;$/;"	m	class:RpcClient	file:
+client_	examples/protobuf/rpcbench/client.cc	/^  TcpClient client_;$/;"	m	class:RpcClient	file:
+client_	examples/simple/chargenclient/chargenclient.cc	/^  TcpClient client_;$/;"	m	class:ChargenClient	file:
+client_	examples/simple/timeclient/timeclient.cc	/^  TcpClient client_;$/;"	m	class:TimeClient	file:
+client_	examples/socks4a/tunnel.h	/^  muduo::net::TcpClient client_;$/;"	m	class:Tunnel
+client_	examples/sudoku/client.cc	/^  TcpClient client_;$/;"	m	class:SudokuClient	file:
+client_	examples/wordcount/hasher.cc	/^  TcpClient client_;$/;"	m	class:SendThrottler	file:
+client_	muduo/net/tests/EchoClient_unittest.cc	/^  TcpClient client_;$/;"	m	class:EchoClient	file:
+client_socket	examples/wordcount/slowsink.py	/^	client_socket = socket.create_connection((host, port))$/;"	v
+clients	muduo/net/tests/EchoClient_unittest.cc	/^boost::ptr_vector<EchoClient> clients;$/;"	v
+close	muduo/net/SocketsOps.cc	/^void sockets::close(int sockfd)$/;"	f	class:sockets
+closeCallback_	muduo/net/Channel.h	/^  EventCallback closeCallback_;$/;"	m	class:muduo::net::Channel
+closeCallback_	muduo/net/TcpConnection.h	/^  CloseCallback closeCallback_;$/;"	m	class:muduo::net::TcpConnection
+closeConnection	muduo/net/http/HttpResponse.h	/^  bool closeConnection() const$/;"	f	class:muduo::net::HttpResponse
+closeConnection_	muduo/net/http/HttpResponse.h	/^  bool closeConnection_;$/;"	m	class:muduo::net::HttpResponse
+cmdline	muduo/net/inspect/PerformanceInspector.cc	/^string PerformanceInspector::cmdline(HttpRequest::Method, const Inspector::ArgList&)$/;"	f	class:PerformanceInspector
+cnt	muduo/net/tests/TimerQueue_unittest.cc	/^int cnt = 0;$/;"	v
+codec_	examples/asio/chat/client.cc	/^  LengthHeaderCodec codec_;$/;"	m	class:ChatClient	file:
+codec_	examples/asio/chat/loadtest.cc	/^  LengthHeaderCodec codec_;$/;"	m	class:ChatClient	file:
+codec_	examples/asio/chat/server.cc	/^  LengthHeaderCodec codec_;$/;"	m	class:ChatServer	file:
+codec_	examples/asio/chat/server_threaded.cc	/^  LengthHeaderCodec codec_;$/;"	m	class:ChatServer	file:
+codec_	examples/asio/chat/server_threaded_efficient.cc	/^  LengthHeaderCodec codec_;$/;"	m	class:ChatServer	file:
+codec_	examples/asio/chat/server_threaded_highperformance.cc	/^  LengthHeaderCodec codec_;$/;"	m	class:ChatServer	file:
+codec_	examples/protobuf/codec/client.cc	/^  ProtobufCodec codec_;$/;"	m	class:QueryClient	file:
+codec_	examples/protobuf/codec/server.cc	/^  ProtobufCodec codec_;$/;"	m	class:QueryServer	file:
+codec_	muduo/net/protorpc/RpcChannel.h	/^  RpcCodec codec_;$/;"	m	class:muduo::net::RpcChannel
+col	examples/sudoku/sudoku.cc	/^    Column* col;$/;"	m	struct:Node	file:
+columns_	examples/sudoku/sudoku.cc	/^    Column* columns_[400];$/;"	m	class:SudokuSolver	file:
+com.chenshuo.muduo.example.multiplexer	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/DataEvent.java	/^package com.chenshuo.muduo.example.multiplexer;$/;"	p
+com.chenshuo.muduo.example.multiplexer	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/Event.java	/^package com.chenshuo.muduo.example.multiplexer;$/;"	p
+com.chenshuo.muduo.example.multiplexer	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/EventQueue.java	/^package com.chenshuo.muduo.example.multiplexer;$/;"	p
+com.chenshuo.muduo.example.multiplexer	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/EventSource.java	/^package com.chenshuo.muduo.example.multiplexer;$/;"	p
+com.chenshuo.muduo.example.multiplexer	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/MockBackendServer.java	/^package com.chenshuo.muduo.example.multiplexer;$/;"	p
+com.chenshuo.muduo.example.multiplexer	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/MockClient.java	/^package com.chenshuo.muduo.example.multiplexer;$/;"	p
+com.chenshuo.muduo.example.multiplexer	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/MultiplexerTest.java	/^package com.chenshuo.muduo.example.multiplexer;$/;"	p
+com.chenshuo.muduo.example.multiplexer	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/MyCountDownLatch.java	/^package com.chenshuo.muduo.example.multiplexer;$/;"	p
+com.chenshuo.muduo.example.multiplexer	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/TestCase.java	/^package com.chenshuo.muduo.example.multiplexer;$/;"	p
+com.chenshuo.muduo.example.multiplexer	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/TestFailedException.java	/^package com.chenshuo.muduo.example.multiplexer;$/;"	p
+com.chenshuo.muduo.example.multiplexer.testcase	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/testcase/TestOneClientBackendSend.java	/^package com.chenshuo.muduo.example.multiplexer.testcase;$/;"	p
+com.chenshuo.muduo.example.multiplexer.testcase	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/testcase/TestOneClientBothSend.java	/^package com.chenshuo.muduo.example.multiplexer.testcase;$/;"	p
+com.chenshuo.muduo.example.multiplexer.testcase	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/testcase/TestOneClientNoData.java	/^package com.chenshuo.muduo.example.multiplexer.testcase;$/;"	p
+com.chenshuo.muduo.example.multiplexer.testcase	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/testcase/TestOneClientSend.java	/^package com.chenshuo.muduo.example.multiplexer.testcase;$/;"	p
+com.chenshuo.muduo.example.multiplexer.testcase	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/testcase/TestTwoClients.java	/^package com.chenshuo.muduo.example.multiplexer.testcase;$/;"	p
+commandChannel	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/MultiplexerTest.java	/^    public final Pattern commandChannel = Pattern.compile("CONN (\\\\d+) FROM [0-9.:]+ IS ([A-Z]+)\\r\\n");$/;"	f	class:MultiplexerTest
+command_	examples/memcached/server/Session.h	/^  string command_;$/;"	m	class:Session
+compare	muduo/base/StringPiece.h	/^  int compare(const StringPiece& x) const {$/;"	f	class:muduo::StringPiece
+compareGmt	muduo/base/TimeZone.cc	/^  bool compareGmt;$/;"	m	struct:muduo::detail::Comp	file:
+concurrentDownload	examples/curl/download.cc	/^  void concurrentDownload()$/;"	f	class:Downloader	file:
+concurrent_	examples/curl/download.cc	/^  int concurrent_;$/;"	m	class:Downloader	file:
+cond_	examples/wordcount/hasher.cc	/^  Condition cond_;$/;"	m	class:SendThrottler	file:
+cond_	muduo/base/AsyncLogging.h	/^  muduo::Condition cond_;$/;"	m	class:muduo::AsyncLogging
+cond_	muduo/net/EventLoopThread.h	/^  Condition cond_;$/;"	m	class:muduo::net::EventLoopThread
+condition_	muduo/base/CountDownLatch.h	/^  Condition condition_;$/;"	m	class:muduo::CountDownLatch
+congestion_	examples/wordcount/hasher.cc	/^  bool congestion_;$/;"	m	class:SendThrottler	file:
+connId	examples/multiplexer/demux.cc	/^  int connId;$/;"	m	struct:Entry	file:
+connId	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/MockClient.java	/^    private int connId;$/;"	f	class:MockClient	file:
+conn_	examples/hub/pubsub.h	/^  muduo::net::TcpConnectionPtr conn_;$/;"	m	class:pubsub::PubSubClient
+conn_	examples/memcached/client/bench.cc	/^  TcpConnectionPtr conn_;$/;"	m	class:Client	file:
+conn_	examples/memcached/server/Session.h	/^  muduo::net::TcpConnectionPtr conn_;$/;"	m	class:Session
+conn_	examples/wordcount/hasher.cc	/^  TcpConnectionPtr conn_;$/;"	m	class:SendThrottler	file:
+conn_	muduo/net/protorpc/RpcChannel.h	/^  TcpConnectionPtr conn_;$/;"	m	class:muduo::net::RpcChannel
+connect	examples/asio/chat/client.cc	/^  void connect()$/;"	f	class:ChatClient
+connect	examples/asio/chat/loadtest.cc	/^  void connect()$/;"	f	class:ChatClient
+connect	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/MockClient.java	/^    public ChannelFuture connect() {$/;"	m	class:MockClient
+connect	examples/netty/discard/client.cc	/^  void connect()$/;"	f	class:DiscardClient
+connect	examples/netty/echo/client.cc	/^  void connect()$/;"	f	class:EchoClient
+connect	examples/netty/uptime/uptime.cc	/^  void connect()$/;"	f	class:UptimeClient
+connect	examples/protobuf/codec/client.cc	/^  void connect()$/;"	f	class:QueryClient
+connect	examples/protobuf/resolver/client.cc	/^  void connect()$/;"	f	class:RpcClient
+connect	examples/protobuf/rpc/client.cc	/^  void connect()$/;"	f	class:RpcClient
+connect	examples/protobuf/rpcbench/client.cc	/^  void connect()$/;"	f	class:RpcClient
+connect	examples/simple/chargenclient/chargenclient.cc	/^  void connect()$/;"	f	class:ChargenClient
+connect	examples/simple/timeclient/timeclient.cc	/^  void connect()$/;"	f	class:TimeClient
+connect	examples/socks4a/tunnel.h	/^  void connect()$/;"	f	class:Tunnel
+connect	examples/sudoku/client.cc	/^  void connect()$/;"	f	class:SudokuClient
+connect	examples/wordcount/hasher.cc	/^  void connect()$/;"	f	class:SendThrottler
+connect	muduo/net/Connector.cc	/^void Connector::connect()$/;"	f	class:Connector
+connect	muduo/net/SocketsOps.cc	/^int sockets::connect(int sockfd, const struct sockaddr_in& addr)$/;"	f	class:sockets
+connect	muduo/net/TcpClient.cc	/^void TcpClient::connect()$/;"	f	class:TcpClient
+connect	muduo/net/tests/EchoClient_unittest.cc	/^  void connect()$/;"	f	class:EchoClient
+connectAll	examples/wordcount/hasher.cc	/^  void connectAll()$/;"	f	class:WordCountSender
+connectAndWait	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/MockClient.java	/^    public void connectAndWait() {$/;"	m	class:MockClient
+connectDestroyed	muduo/net/TcpConnection.cc	/^void TcpConnection::connectDestroyed()$/;"	f	class:TcpConnection
+connectEstablished	muduo/net/TcpConnection.cc	/^void TcpConnection::connectEstablished()$/;"	f	class:TcpConnection
+connectLatch_	examples/wordcount/hasher.cc	/^  CountDownLatch connectLatch_;$/;"	m	class:SendThrottler	file:
+connect_	muduo/net/Connector.h	/^  bool connect_; \/\/ atomic$/;"	m	class:muduo::net::Connector
+connect_	muduo/net/TcpClient.h	/^  bool connect_; \/\/ atomic$/;"	m	class:muduo::net::TcpClient
+connected	examples/hub/pubsub.cc	/^bool PubSubClient::connected() const$/;"	f	class:PubSubClient
+connected	muduo/net/TcpConnection.h	/^  bool connected() const { return state_ == kConnected; }$/;"	f	class:muduo::net::TcpConnection
+connected_	examples/memcached/client/bench.cc	/^  CountDownLatch* const connected_;$/;"	m	class:Client	file:
+connecting	muduo/net/Connector.cc	/^void Connector::connecting(int sockfd)$/;"	f	class:Connector
+connection	examples/hub/pub.cc	/^void connection(PubSubClient* client)$/;"	f
+connection	examples/hub/sub.cc	/^void connection(PubSubClient* client)$/;"	f
+connection	examples/multiplexer/demux.cc	/^  TcpConnectionPtr connection;$/;"	m	struct:Entry	file:
+connection	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/MockBackendServer.java	/^    private volatile Channel connection;$/;"	f	class:MockBackendServer	file:
+connection	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/MockClient.java	/^    private volatile Channel connection;$/;"	f	class:MockClient	file:
+connection	muduo/net/TcpClient.h	/^  TcpConnectionPtr connection() const$/;"	f	class:muduo::net::TcpClient
+connectionBuckets_	examples/idleconnection/echo.h	/^  WeakConnectionList connectionBuckets_;$/;"	m	class:EchoServer
+connectionCallback_	examples/hub/pubsub.h	/^  ConnectionCallback connectionCallback_;$/;"	m	class:pubsub::PubSubClient
+connectionCallback_	muduo/net/TcpClient.h	/^  ConnectionCallback connectionCallback_;$/;"	m	class:muduo::net::TcpClient
+connectionCallback_	muduo/net/TcpConnection.h	/^  ConnectionCallback connectionCallback_;$/;"	m	class:muduo::net::TcpConnection
+connectionCallback_	muduo/net/TcpServer.h	/^  ConnectionCallback connectionCallback_;$/;"	m	class:muduo::net::TcpServer
+connectionList_	examples/idleconnection/sortedlist.cc	/^  WeakConnectionList connectionList_;$/;"	m	class:EchoServer	file:
+connection_	examples/asio/chat/client.cc	/^  TcpConnectionPtr connection_;$/;"	m	class:ChatClient	file:
+connection_	examples/asio/chat/loadtest.cc	/^  TcpConnectionPtr connection_;$/;"	m	class:ChatClient	file:
+connection_	muduo/net/TcpClient.h	/^  TcpConnectionPtr connection_; \/\/ @BuardedBy mutex_$/;"	m	class:muduo::net::TcpClient
+connections_	examples/asio/chat/server.cc	/^  ConnectionList connections_;$/;"	m	class:ChatServer	file:
+connections_	examples/asio/chat/server_threaded.cc	/^  ConnectionList connections_;$/;"	m	class:ChatServer	file:
+connections_	examples/asio/chat/server_threaded_efficient.cc	/^  ConnectionListPtr connections_;$/;"	m	class:ChatServer	file:
+connections_	muduo/net/TcpServer.h	/^  ConnectionMap connections_;$/;"	m	class:muduo::net::TcpServer
+connector_	muduo/net/TcpClient.h	/^  ConnectorPtr connector_; \/\/ avoid revealing Connector$/;"	m	class:muduo::net::TcpClient
+content_	examples/hub/hub.cc	/^  string content_;$/;"	m	class:pubsub::Topic	file:
+context_	muduo/net/TcpConnection.h	/^  boost::any context_;$/;"	m	class:muduo::net::TcpConnection
+convert	muduo/base/LogStream.cc	/^size_t convert(char buf[], T value)$/;"	f	namespace:muduo::detail
+convertHex	muduo/base/LogStream.cc	/^size_t convertHex(char buf[], uintptr_t value)$/;"	f	namespace:muduo::detail
+cookieEnd	muduo/base/LogStream.cc	/^void FixedBuffer<SIZE>::cookieEnd()$/;"	f	class:FixedBuffer
+cookieStart	muduo/base/LogStream.cc	/^void FixedBuffer<SIZE>::cookieStart()$/;"	f	class:FixedBuffer
+cookie_	muduo/base/LogStream.h	/^  void (*cookie_)();$/;"	m	class:muduo::detail::FixedBuffer
+copyable	muduo/base/copyable.h	/^class copyable$/;"	c	namespace:muduo
+count	examples/cdns/dns.cc	/^int count = 0;$/;"	v
+countDown	muduo/base/CountDownLatch.cc	/^void CountDownLatch::countDown()$/;"	f	class:CountDownLatch
+count_	examples/asio/tutorial/timer4/timer.cc	/^  int count_;$/;"	m	class:Printer	file:
+count_	examples/asio/tutorial/timer5/timer.cc	/^  int count_;$/;"	m	class:Printer	file:
+count_	examples/asio/tutorial/timer6/timer.cc	/^  int count_;$/;"	m	class:Printer	file:
+count_	examples/protobuf/rpcbench/client.cc	/^  int count_;$/;"	m	class:RpcClient	file:
+count_	examples/sudoku/client.cc	/^  size_t count_;$/;"	m	class:SudokuClient	file:
+count_	muduo/base/CountDownLatch.h	/^  int count_;$/;"	m	class:muduo::CountDownLatch
+count_	muduo/base/LogFile.h	/^  int count_;$/;"	m	class:muduo::LogFile
+cover	examples/sudoku/sudoku.cc	/^    void cover(Column* c)$/;"	f	class:SudokuSolver	file:
+createEventfd	muduo/net/EventLoop.cc	/^int createEventfd()$/;"	f	namespace:__anon4
+createMessage	examples/protobuf/codec/codec.cc	/^google::protobuf::Message* ProtobufCodec::createMessage(const std::string& typeName)$/;"	f	class:ProtobufCodec
+createNonblockingOrDie	muduo/net/SocketsOps.cc	/^int sockets::createNonblockingOrDie()$/;"	f	class:sockets
+createNonblockingUDP	examples/roundtrip/roundtrip_udp.cc	/^int createNonblockingUDP()$/;"	f
+createTimerfd	muduo/net/TimerQueue.cc	/^int createTimerfd()$/;"	f	namespace:muduo::net::detail
+created	examples/filetransfer/loadtest/Handler.java	/^    private static int created = 0;$/;"	f	class:Handler	file:
+ctx_	examples/cdns/Resolver.h	/^  ares_channel ctx_;$/;"	m	class:cdns::Resolver
+cur_	muduo/base/LogStream.h	/^  char* cur_;$/;"	m	class:muduo::detail::FixedBuffer
+cur_node_	examples/sudoku/sudoku.cc	/^    int     cur_node_;$/;"	m	class:SudokuSolver	file:
+curl	examples/curl/Curl.h	/^namespace curl$/;"	n
+curl_	examples/curl/Curl.h	/^  CURL* curl_;$/;"	m	class:curl::Request
+curl_	examples/curl/download.cc	/^  curl::Curl curl_;$/;"	m	class:Downloader	file:
+curlm_	examples/curl/Curl.h	/^  CURLM* curlm_;$/;"	m	class:curl::Curl
+currItem_	examples/memcached/server/Session.h	/^  ItemPtr currItem_;$/;"	m	class:Session
+current	muduo/base/LogStream.h	/^  char* current() { return cur_; }$/;"	f	class:muduo::detail::FixedBuffer
+current	muduo/net/tests/EchoClient_unittest.cc	/^int current = 0;$/;"	v
+currentActiveChannel_	muduo/net/EventLoop.h	/^  Channel* currentActiveChannel_;$/;"	m	class:muduo::net::EventLoop
+currentBuffer_	muduo/base/AsyncLogging.h	/^  BufferPtr currentBuffer_;$/;"	m	class:muduo::AsyncLogging
+data	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/DataEvent.java	/^    public final ChannelBuffer data;$/;"	f	class:DataEvent
+data	examples/wordcount/slowsink.py	/^	data = client_socket.recv(BUFSIZE)$/;"	v
+data	muduo/base/LogStream.h	/^  const char* data() const { return buf_; }$/;"	f	class:muduo::Fmt
+data	muduo/base/LogStream.h	/^  const char* data() const { return data_; }$/;"	f	class:muduo::detail::FixedBuffer
+data	muduo/base/StringPiece.h	/^  const char* data() const { return ptr_; }$/;"	f	class:muduo::StringPiece
+dataCallback	examples/curl/Curl.cc	/^void Request::dataCallback(const char* buffer, int len)$/;"	f	class:Request
+dataCb_	examples/curl/Curl.h	/^  DataCallback dataCb_;$/;"	m	class:curl::Request
+data_	examples/memcached/server/Item.h	/^  char*          data_;$/;"	m	class:Item
+data_	muduo/base/LogStream.h	/^  char data_[SIZE];$/;"	m	class:muduo::detail::FixedBuffer
+data_	muduo/base/Logging.h	/^    const char* data_;$/;"	m	class:muduo::Logger::SourceFile
+data_	muduo/base/TimeZone.h	/^  boost::shared_ptr<Data> data_;$/;"	m	class:muduo::TimeZone
+day	muduo/base/Date.h	/^    int day;  \/\/ [1..31]$/;"	m	struct:muduo::Date::YearMonthDay
+day	muduo/base/Date.h	/^  int day() const$/;"	f	class:muduo::Date
+daysOfMonth	muduo/base/tests/Date_unittest.cc	/^int daysOfMonth(int year, int month)$/;"	f
+debugString	muduo/base/LogStream.cc	/^const char* FixedBuffer<SIZE>::debugString()$/;"	f	class:FixedBuffer
+decrement	muduo/base/Atomic.h	/^  void decrement()$/;"	f	class:muduo::detail::AtomicIntegerT
+decrementAndGet	muduo/base/Atomic.h	/^  T decrementAndGet()$/;"	f	class:muduo::detail::AtomicIntegerT
+defaultCallback_	examples/protobuf/codec/dispatcher.h	/^  ProtobufMessageCallback defaultCallback_;$/;"	m	class:ProtobufDispatcher
+defaultCallback_	examples/protobuf/codec/dispatcher_lite.h	/^  ProtobufMessageCallback defaultCallback_;$/;"	m	class:ProtobufDispatcherLite
+defaultConnectionCallback	muduo/net/TcpConnection.cc	/^void muduo::net::defaultConnectionCallback(const TcpConnectionPtr& conn)$/;"	f	class:muduo::net
+defaultErrorCallback	examples/protobuf/codec/codec.cc	/^void ProtobufCodec::defaultErrorCallback(const muduo::net::TcpConnectionPtr& conn,$/;"	f	class:ProtobufCodec
+defaultErrorCallback	muduo/net/protorpc/RpcCodec.cc	/^void RpcCodec::defaultErrorCallback(const TcpConnectionPtr& conn,$/;"	f	class:RpcCodec
+defaultFlush	muduo/base/Logging.cc	/^void defaultFlush()$/;"	f	namespace:muduo
+defaultHttpCallback	muduo/net/http/HttpServer.cc	/^void defaultHttpCallback(const HttpRequest&, HttpResponse* resp)$/;"	f	namespace:muduo::net::detail
+defaultMessageCallback	muduo/net/TcpConnection.cc	/^void muduo::net::defaultMessageCallback(const TcpConnectionPtr&,$/;"	f	class:muduo::net
+defaultOutput	muduo/base/Logging.cc	/^void defaultOutput(const char* msg, int len)$/;"	f	namespace:muduo
+deleteItem	examples/memcached/server/MemcacheServer.cc	/^bool MemcacheServer::deleteItem(const ConstItemPtr& key)$/;"	f	class:MemcacheServer
+deleter_	muduo/base/ThreadLocalSingleton.h	/^  static Deleter deleter_;$/;"	m	class:muduo::ThreadLocalSingleton
+deleter_	muduo/base/ThreadLocalSingleton.h	/^typename ThreadLocalSingleton<T>::Deleter ThreadLocalSingleton<T>::deleter_;$/;"	m	class:muduo::ThreadLocalSingleton
+destroy	muduo/base/Singleton.h	/^  static void destroy()$/;"	f	class:muduo::Singleton
+destructor	muduo/base/ThreadLocal.h	/^  static void destructor(void *x)$/;"	f	class:muduo::ThreadLocal
+destructor	muduo/base/ThreadLocalSingleton.h	/^  static void destructor(void* obj)$/;"	f	class:muduo::ThreadLocalSingleton
+detail	muduo/base/Atomic.h	/^namespace detail$/;"	n	namespace:muduo
+detail	muduo/base/Date.cc	/^namespace detail$/;"	n	namespace:muduo	file:
+detail	muduo/base/LogStream.cc	/^namespace detail$/;"	n	namespace:muduo	file:
+detail	muduo/base/LogStream.h	/^namespace detail$/;"	n	namespace:muduo
+detail	muduo/base/ProcessInfo.cc	/^namespace detail$/;"	n	namespace:muduo	file:
+detail	muduo/base/Thread.cc	/^namespace detail$/;"	n	namespace:muduo	file:
+detail	muduo/base/TimeZone.cc	/^namespace detail$/;"	n	namespace:muduo	file:
+detail	muduo/net/TcpClient.cc	/^namespace detail$/;"	n	namespace:muduo::net	file:
+detail	muduo/net/TimerQueue.cc	/^namespace detail$/;"	n	namespace:muduo::net	file:
+detail	muduo/net/http/HttpServer.cc	/^namespace detail$/;"	n	namespace:muduo::net	file:
+detail	muduo/net/http/tests/HttpRequest_unittest.cc	/^namespace detail$/;"	n	namespace:muduo::net	file:
+digest	examples/filetransfer/loadtest/Handler.java	/^    private MessageDigest digest;$/;"	f	class:Handler	file:
+digits	muduo/base/LogStream.cc	/^const char digits[] = "9876543210123456789";$/;"	m	namespace:muduo::detail	file:
+digitsHex	muduo/base/LogStream.cc	/^const char digitsHex[] = "0123456789ABCDEF";$/;"	m	namespace:muduo::detail	file:
+disableAll	muduo/net/Channel.h	/^  void disableAll() { events_ = kNoneEvent; update(); }$/;"	f	class:muduo::net::Channel
+disableWriting	muduo/net/Channel.h	/^  void disableWriting() { events_ &= ~kWriteEvent; update(); }$/;"	f	class:muduo::net::Channel
+discardValue	examples/memcached/server/Session.cc	/^void Session::discardValue(muduo::net::Buffer* buf)$/;"	f	class:Session
+disconnect	examples/asio/chat/client.cc	/^  void disconnect()$/;"	f	class:ChatClient
+disconnect	examples/asio/chat/loadtest.cc	/^  void disconnect()$/;"	f	class:ChatClient
+disconnect	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/MockClient.java	/^    public void disconnect() {$/;"	m	class:MockClient
+disconnect	examples/socks4a/tunnel.h	/^  void disconnect()$/;"	f	class:Tunnel
+disconnect	examples/wordcount/hasher.cc	/^  void disconnect()$/;"	f	class:SendThrottler
+disconnect	muduo/net/TcpClient.cc	/^void TcpClient::disconnect()$/;"	f	class:TcpClient
+disconnectAll	examples/wordcount/hasher.cc	/^  void disconnectAll()$/;"	f	class:WordCountSender
+disconnectLatch_	examples/wordcount/hasher.cc	/^  CountDownLatch disconnectLatch_;$/;"	m	class:SendThrottler	file:
+dispatcher_	examples/protobuf/codec/client.cc	/^  ProtobufDispatcher dispatcher_;$/;"	m	class:QueryClient	file:
+dispatcher_	examples/protobuf/codec/server.cc	/^  ProtobufDispatcher dispatcher_;$/;"	m	class:QueryServer	file:
+distributeMessage	examples/asio/chat/server_threaded_highperformance.cc	/^  void distributeMessage(const string& message)$/;"	f	class:ChatServer	file:
+doCommand	examples/multiplexer/demux.cc	/^  void doCommand(const string& cmd)$/;"	f	class:DemuxServer
+doCommand	examples/multiplexer/multiplexer_simple.cc	/^  void doCommand(const string& cmd)$/;"	f	class:MultiplexServer	file:
+doDelete	examples/memcached/server/Session.cc	/^void Session::doDelete(Session::Tokenizer::iterator& beg, Session::Tokenizer::iterator end)$/;"	f	class:Session
+doNotLogHup	muduo/net/Channel.h	/^  void doNotLogHup() { logHup_ = false; }$/;"	f	class:muduo::net::Channel
+doPendingFunctors	muduo/net/EventLoop.cc	/^void EventLoop::doPendingFunctors()$/;"	f	class:EventLoop
+doPublish	examples/hub/hub.cc	/^  void doPublish(const string& source,$/;"	f	class:pubsub::PubSubServer	file:
+doSubscribe	examples/hub/hub.cc	/^  void doSubscribe(const TcpConnectionPtr& conn,$/;"	f	class:pubsub::PubSubServer	file:
+doUnsubscribe	examples/hub/hub.cc	/^  void doUnsubscribe(const TcpConnectionPtr& conn,$/;"	f	class:pubsub::PubSubServer	file:
+doUpdate	examples/memcached/server/Session.cc	/^bool Session::doUpdate(Session::Tokenizer::iterator& beg, Session::Tokenizer::iterator end)$/;"	f	class:Session
+done	examples/curl/Curl.cc	/^void Request::done(int code)$/;"	f	class:Request
+done	examples/curl/mcurl.cc	/^void done(curl::Request* c, int code)$/;"	f
+done	examples/sudoku/client.cc	/^void done(const string& name, double elapsed)$/;"	f
+done	muduo/net/protorpc/RpcChannel.h	/^    ::google::protobuf::Closure* done;$/;"	m	struct:muduo::net::RpcChannel::OutstandingCall
+done2	examples/curl/mcurl.cc	/^void done2(curl::Request* c, int code)$/;"	f
+doneCallback	examples/protobuf/resolver/server.cc	/^  void doneCallback(const std::string& host,$/;"	f	class:resolver::ResolverServiceImpl	file:
+doneCallback	muduo/net/protorpc/RpcChannel.cc	/^void RpcChannel::doneCallback(::google::protobuf::Message* response, int64_t id)$/;"	f	class:RpcChannel
+doneCb_	examples/curl/Curl.h	/^  DoneCallback doneCb_;$/;"	m	class:curl::Request
+doneCb_	examples/curl/download.cc	/^  boost::function<void()> doneCb_;$/;"	m	class:Piece	file:
+dot	examples/wordcount/slowsink.py	/^dot = bps$/;"	v
+down	examples/sudoku/sudoku.cc	/^    Node* down;$/;"	m	struct:Node	file:
+down_cast	muduo/base/Types.h	/^inline To down_cast(From* f) {                   \/\/ so we only accept pointers$/;"	f	namespace:muduo
+down_pointer_cast	muduo/net/Callbacks.h	/^inline ::boost::shared_ptr<To> down_pointer_cast(const ::boost::shared_ptr<From>& f) {$/;"	f	namespace:muduo
+dummy	examples/curl/Curl.cc	/^static void dummy(const boost::shared_ptr<Channel>&)$/;"	f	file:
+dummy	muduo/net/protorpc/RpcCodec.cc	/^  int dummy = ProtobufVersionCheck();$/;"	m	namespace:__anon5	file:
+dummyOutput	muduo/base/tests/Logging_test.cc	/^void dummyOutput(const char* msg, int len)$/;"	f
+dumpConnectionBuckets	examples/idleconnection/echo.cc	/^void EchoServer::dumpConnectionBuckets() const$/;"	f	class:EchoServer
+dumpConnectionList	examples/idleconnection/sortedlist.cc	/^void EchoServer::dumpConnectionList() const$/;"	f	class:EchoServer
+echo	examples/protobuf/rpcbench/server.cc	/^namespace echo$/;"	n	file:
+elapsed	examples/wordcount/slowsink.py	/^elapsed = end - start$/;"	v
+empty	muduo/base/BoundedBlockingQueue.h	/^  bool empty() const$/;"	f	class:muduo::BoundedBlockingQueue
+empty	muduo/base/StringPiece.h	/^  bool empty() const { return length_ == 0; }$/;"	f	class:muduo::StringPiece
+enableReading	muduo/net/Channel.h	/^  void enableReading() { events_ |= kReadEvent; update(); }$/;"	f	class:muduo::net::Channel
+enableRetry	muduo/net/TcpClient.h	/^  void enableRetry() { retry_ = true; }$/;"	f	class:muduo::net::TcpClient
+enableWriting	muduo/net/Channel.h	/^  void enableWriting() { events_ |= kWriteEvent; update(); }$/;"	f	class:muduo::net::Channel
+end	examples/wordcount/slowsink.py	/^end = time.time()$/;"	v
+end	muduo/base/LogStream.h	/^  const char* end() const { return data_ + sizeof data_; }$/;"	f	class:muduo::detail::FixedBuffer
+end	muduo/base/StringPiece.h	/^  const char* end() const { return ptr_ + length_; }$/;"	f	class:muduo::StringPiece
+endRequest	examples/fastcgi/fastcgi.cc	/^void FastCgiCodec::endRequest(Buffer* buf)$/;"	f	class:FastCgiCodec
+endStdout	examples/fastcgi/fastcgi.cc	/^void FastCgiCodec::endStdout(Buffer* buf)$/;"	f	class:FastCgiCodec
+endsWithCRLF	examples/memcached/server/Item.h	/^  bool endsWithCRLF() const$/;"	f	class:Item
+ensureWritableBytes	muduo/net/Buffer.h	/^  void ensureWritableBytes(size_t len)$/;"	f	class:muduo::net::Buffer
+epollfd_	muduo/net/poller/EPollPoller.h	/^  int epollfd_;$/;"	m	class:muduo::net::EPollPoller
+equal	muduo/base/TimeZone.cc	/^  bool equal(const Transition& lhs, const Transition& rhs) const$/;"	f	struct:muduo::detail::Comp
+err_	muduo/base/FileUtil.h	/^    int err_;$/;"	m	class:muduo::FileUtil::SmallFile
+errorCallback_	examples/protobuf/codec/codec.h	/^  ErrorCallback errorCallback_;$/;"	m	class:ProtobufCodec
+errorCallback_	muduo/net/Channel.h	/^  EventCallback errorCallback_;$/;"	m	class:muduo::net::Channel
+errorCallback_	muduo/net/protorpc/RpcCodec.h	/^  ErrorCallback errorCallback_;$/;"	m	class:muduo::net::RpcCodec
+errorCodeToString	examples/protobuf/codec/codec.cc	/^const string& ProtobufCodec::errorCodeToString(ErrorCode errorCode)$/;"	f	class:ProtobufCodec
+errorCodeToString	muduo/net/protorpc/RpcCodec.cc	/^const string& RpcCodec::errorCodeToString(ErrorCode errorCode)$/;"	f	class:RpcCodec
+euid	muduo/base/ProcessInfo.cc	/^uid_t ProcessInfo::euid()$/;"	f	class:ProcessInfo
+eventHandling	muduo/net/EventLoop.h	/^  bool eventHandling() const { return eventHandling_; }$/;"	f	class:muduo::net::EventLoop
+eventHandling_	muduo/net/Channel.h	/^  bool eventHandling_;$/;"	m	class:muduo::net::Channel
+eventHandling_	muduo/net/EventLoop.h	/^  bool eventHandling_; \/* atomic *\/$/;"	m	class:muduo::net::EventLoop
+events	muduo/net/Channel.h	/^  int events() const { return events_; }$/;"	f	class:muduo::net::Channel
+events_	muduo/net/Channel.h	/^  int        events_;$/;"	m	class:muduo::net::Channel
+events_	muduo/net/poller/EPollPoller.h	/^  EventList events_;$/;"	m	class:muduo::net::EPollPoller
+exceptionCaught	examples/filetransfer/loadtest/Handler.java	/^    public void exceptionCaught(ChannelHandlerContext ctx, ExceptionEvent e) throws Exception {$/;"	m	class:Handler
+exceptionCaught	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/MockBackendServer.java	/^        public void exceptionCaught(ChannelHandlerContext ctx, ExceptionEvent e)$/;"	m	class:MockBackendServer.Handler
+exceptionCaught	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/MockClient.java	/^        public void exceptionCaught(ChannelHandlerContext ctx, ExceptionEvent e)$/;"	m	class:MockClient.Handler
+exePath	muduo/base/ProcessInfo.cc	/^string ProcessInfo::exePath()$/;"	f	class:ProcessInfo
+exiting_	muduo/net/EventLoopThread.h	/^  bool exiting_;$/;"	m	class:muduo::net::EventLoopThread
+expectBody	muduo/net/http/HttpContext.h	/^  bool expectBody() const$/;"	f	class:muduo::net::HttpContext
+expectHeaders	muduo/net/http/HttpContext.h	/^  bool expectHeaders() const$/;"	f	class:muduo::net::HttpContext
+expectRequestLine	muduo/net/http/HttpContext.h	/^  bool expectRequestLine() const$/;"	f	class:muduo::net::HttpContext
+expiration	muduo/net/Timer.h	/^  Timestamp expiration() const  { return expiration_; }$/;"	f	class:muduo::net::Timer
+expiration_	muduo/net/Timer.h	/^  Timestamp expiration_;$/;"	m	class:muduo::net::Timer
+fail	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/TestCase.java	/^    protected void fail(String message) {$/;"	m	class:TestCase
+favicon	examples/shorturl/shorturl.cc	/^char favicon[555] = {$/;"	v
+favicon	muduo/net/http/tests/HttpServer_test.cc	/^char favicon[555] = {$/;"	v
+favicon	muduo/net/inspect/Inspector.cc	/^char favicon[1743] =$/;"	v
+fd	muduo/net/Channel.h	/^  int fd() const { return fd_; }$/;"	f	class:muduo::net::Channel
+fd	muduo/net/Socket.h	/^  int fd() const { return sockfd_; }$/;"	f	class:muduo::net::Socket
+fdDirFilter	muduo/base/ProcessInfo.cc	/^int fdDirFilter(const struct dirent* d)$/;"	f	namespace:muduo::detail
+fd_	muduo/base/FileUtil.h	/^    int fd_;$/;"	m	class:muduo::FileUtil::SmallFile
+fd_	muduo/net/Channel.h	/^  const int  fd_;$/;"	m	class:muduo::net::Channel
+file_	muduo/base/LogFile.h	/^  boost::scoped_ptr<File> file_;$/;"	m	class:muduo::LogFile
+fill	examples/memcached/client/bench.cc	/^  void fill(Buffer* buf)$/;"	f	class:Client	file:
+fillActiveChannels	muduo/net/poller/EPollPoller.cc	/^void EPollPoller::fillActiveChannels(int numEvents,$/;"	f	class:EPollPoller
+fillActiveChannels	muduo/net/poller/PollPoller.cc	/^void PollPoller::fillActiveChannels(int numEvents,$/;"	f	class:PollPoller
+fillEmptyBuffer	examples/protobuf/codec/codec.cc	/^void ProtobufCodec::fillEmptyBuffer(Buffer* buf, const google::protobuf::Message& message)$/;"	f	class:ProtobufCodec
+fillHMS	muduo/base/TimeZone.cc	/^inline void fillHMS(unsigned seconds, struct tm* utc)$/;"	f	namespace:muduo::detail
+fillStackTrace	muduo/base/Exception.cc	/^void Exception::fillStackTrace()$/;"	f	class:Exception
+findCRLF	muduo/net/Buffer.h	/^  const char* findCRLF() const$/;"	f	class:muduo::net::Buffer
+findCRLF	muduo/net/Buffer.h	/^  const char* findCRLF(const char* start) const$/;"	f	class:muduo::net::Buffer
+findEOL	muduo/net/Buffer.h	/^  const char* findEOL() const$/;"	f	class:muduo::net::Buffer
+findEOL	muduo/net/Buffer.h	/^  const char* findEOL(const char* start) const$/;"	f	class:muduo::net::Buffer
+findLocaltime	muduo/base/TimeZone.cc	/^const Localtime* findLocaltime(const TimeZone::Data& data, Transition sentry, Comp comp)$/;"	f	namespace:muduo::detail
+finish	muduo/base/Logging.cc	/^void Logger::Impl::finish()$/;"	f	class:Logger::Impl
+finished_	examples/memcached/client/bench.cc	/^  CountDownLatch* const finished_;$/;"	m	class:Client	file:
+first_	examples/memcached/server/Session.cc	/^  Tokenizer::iterator first_;$/;"	m	struct:Session::Reader	file:
+flags	examples/memcached/server/Item.h	/^  uint32_t flags() const$/;"	f	class:Item
+flags_	examples/memcached/server/Item.h	/^  const uint32_t flags_;$/;"	m	class:Item
+flush	muduo/base/LogFile.cc	/^  void flush()$/;"	f	class:LogFile::File
+flush	muduo/base/LogFile.cc	/^void LogFile::flush()$/;"	f	class:LogFile
+flushFunc	muduo/base/tests/LogFile_test.cc	/^void flushFunc()$/;"	f
+flushInterval_	muduo/base/AsyncLogging.h	/^  const int flushInterval_;$/;"	m	class:muduo::AsyncLogging
+flushInterval_	muduo/base/LogFile.h	/^  const int flushInterval_;$/;"	m	class:muduo::LogFile
+foo	muduo/base/tests/Exception_test.cc	/^void foo()$/;"	f
+foo	muduo/base/tests/Mutex_test.cc	/^int foo()$/;"	f
+forkBench	muduo/base/tests/Thread_bench.cc	/^void forkBench()$/;"	f
+formatInteger	muduo/base/LogStream.cc	/^void LogStream::formatInteger(T v)$/;"	f	class:LogStream
+formatTime	muduo/base/Logging.cc	/^void Logger::Impl::formatTime()$/;"	f	class:Logger::Impl
+found_	examples/curl/download.cc	/^  bool found_;$/;"	m	class:Downloader	file:
+fp_	muduo/base/LogFile.cc	/^  FILE* fp_;$/;"	m	class:LogFile::File	file:
+fp_	muduo/base/TimeZone.cc	/^  FILE* fp_;$/;"	m	class:muduo::detail::File	file:
+frameLen	examples/roundtrip/roundtrip.cc	/^const size_t frameLen = 2*sizeof(int64_t);$/;"	v
+frameLen	examples/roundtrip/roundtrip_udp.cc	/^const size_t frameLen = 2*sizeof(int64_t);$/;"	v
+fromIpPort	muduo/net/SocketsOps.cc	/^void sockets::fromIpPort(const char* ip, uint16_t port,$/;"	f	class:sockets
+fromLocalTime	muduo/base/TimeZone.cc	/^time_t TimeZone::fromLocalTime(const struct tm& localTm) const$/;"	f	class:TimeZone
+fromUtcTime	muduo/base/TimeZone.cc	/^time_t TimeZone::fromUtcTime(const struct tm& utc)$/;"	f	class:TimeZone
+fromUtcTime	muduo/base/TimeZone.cc	/^time_t TimeZone::fromUtcTime(int year, int month, int day,$/;"	f	class:TimeZone
+full	muduo/base/BoundedBlockingQueue.h	/^  bool full() const$/;"	f	class:muduo::BoundedBlockingQueue
+func_	muduo/base/Thread.cc	/^  ThreadFunc func_;$/;"	m	struct:muduo::detail::ThreadData	file:
+func_	muduo/base/Thread.h	/^  ThreadFunc func_;$/;"	m	class:muduo::Thread
+fwrite_unlocked	muduo/base/LogFile.cc	63;"	d	file:
+g_aliveConnections	examples/asio/chat/loadtest.cc	/^AtomicInt32 g_aliveConnections;$/;"	v
+g_asyncLog	muduo/base/tests/AsyncLogging_test.cc	/^muduo::AsyncLogging* g_asyncLog = NULL;$/;"	v
+g_channels	examples/pingpong/bench.cc	/^boost::ptr_vector<Channel> g_channels;$/;"	v
+g_connections	examples/asio/chat/loadtest.cc	/^int g_connections = 0;$/;"	v
+g_connections	examples/sudoku/client.cc	/^int g_connections;$/;"	v
+g_content	examples/hub/pub.cc	/^string g_content;$/;"	v
+g_count	examples/protobuf/codec/codec_test.cc	/^int g_count = 0;$/;"	v
+g_count	muduo/base/tests/Mutex_test.cc	/^int g_count = 0;$/;"	v
+g_delays	muduo/base/tests/Thread_bench.cc	/^std::map<int, int> g_delays;$/;"	v
+g_file	examples/filetransfer/download.cc	/^const char* g_file = NULL;$/;"	v
+g_file	examples/filetransfer/download2.cc	/^const char* g_file = NULL;$/;"	v
+g_file	examples/filetransfer/download3.cc	/^const char* g_file = NULL;$/;"	v
+g_file	muduo/base/tests/Logging_test.cc	/^FILE* g_file;$/;"	v
+g_finished	examples/sudoku/client.cc	/^int g_finished;$/;"	v
+g_fired	examples/pingpong/bench.cc	/^int g_reads, g_writes, g_fired;$/;"	v
+g_flush	muduo/base/Logging.cc	/^Logger::FlushFunc g_flush = defaultFlush;$/;"	m	namespace:muduo	file:
+g_globalInspector	muduo/net/inspect/Inspector.cc	/^Inspector* g_globalInspector = 0;$/;"	m	namespace:__anon2	file:
+g_logFile	muduo/base/tests/LogFile_test.cc	/^boost::scoped_ptr<muduo::LogFile> g_logFile;$/;"	v
+g_logFile	muduo/base/tests/Logging_test.cc	/^boost::scoped_ptr<muduo::LogFile> g_logFile;$/;"	v
+g_logLevel	muduo/base/Logging.cc	/^Logger::LogLevel g_logLevel = initLogLevel();$/;"	m	namespace:muduo	file:
+g_loop	examples/asio/chat/loadtest.cc	/^EventLoop* g_loop;$/;"	v
+g_loop	examples/pingpong/bench.cc	/^EventLoop* g_loop;$/;"	v
+g_loop	examples/sudoku/client.cc	/^EventLoop* g_loop;$/;"	v
+g_loop	muduo/net/tests/TimerQueue_unittest.cc	/^EventLoop* g_loop;$/;"	v
+g_message	examples/zeromq/remote_lat.cc	/^muduo::string g_message;$/;"	v
+g_messagesReceived	examples/asio/chat/loadtest.cc	/^AtomicInt32 g_messagesReceived;$/;"	v
+g_msgCount	examples/zeromq/remote_lat.cc	/^int g_msgCount = 0;$/;"	v
+g_msgSize	examples/zeromq/remote_lat.cc	/^int g_msgSize = 0;$/;"	v
+g_mutex	muduo/base/tests/Thread_bench.cc	/^muduo::MutexLock g_mutex;$/;"	v
+g_output	muduo/base/Logging.cc	/^Logger::OutputFunc g_output = defaultOutput;$/;"	m	namespace:muduo	file:
+g_reads	examples/pingpong/bench.cc	/^int g_reads, g_writes, g_fired;$/;"	v
+g_receiveTime	examples/asio/chat/loadtest.cc	/^std::vector<Timestamp> g_receiveTime;$/;"	v
+g_serverAddr	examples/socks4a/tcprelay.cc	/^InetAddress* g_serverAddr;$/;"	v
+g_start	examples/sudoku/client.cc	/^Timestamp g_start;$/;"	v
+g_start	examples/zeromq/remote_lat.cc	/^muduo::Timestamp g_start;$/;"	v
+g_startTime	examples/asio/chat/loadtest.cc	/^Timestamp g_startTime;$/;"	v
+g_startTime	muduo/base/ProcessInfo.cc	/^Timestamp g_startTime = Timestamp::now();$/;"	m	namespace:muduo::detail	file:
+g_statistic	examples/asio/chat/loadtest.cc	/^boost::function<void()> g_statistic;$/;"	v
+g_tcpNoDelay	examples/zeromq/local_lat.cc	/^bool g_tcpNoDelay = false;$/;"	v
+g_tcpNoDelay	examples/zeromq/remote_lat.cc	/^bool g_tcpNoDelay = false;$/;"	v
+g_topic	examples/hub/pub.cc	/^string g_topic;$/;"	v
+g_topics	examples/hub/sub.cc	/^std::vector<string> g_topics;$/;"	v
+g_total	muduo/base/tests/Logging_test.cc	/^int g_total;$/;"	v
+g_totalMsgs	examples/zeromq/remote_lat.cc	/^int g_totalMsgs = 0;$/;"	v
+g_tunnels	examples/socks4a/socks4a.cc	/^std::map<string, TunnelPtr> g_tunnels;$/;"	v
+g_tunnels	examples/socks4a/tcprelay.cc	/^std::map<string, TunnelPtr> g_tunnels;$/;"	v
+g_vec	muduo/base/tests/Mutex_test.cc	/^vector<int> g_vec;$/;"	v
+g_writes	examples/pingpong/bench.cc	/^int g_reads, g_writes, g_fired;$/;"	v
+get	muduo/base/Atomic.h	/^  T get()$/;"	f	class:muduo::detail::AtomicIntegerT
+getAndAdd	muduo/base/Atomic.h	/^  T getAndAdd(T x)$/;"	f	class:muduo::detail::AtomicIntegerT
+getAndSet	muduo/base/Atomic.h	/^  T getAndSet(T newValue)$/;"	f	class:muduo::detail::AtomicIntegerT
+getBackend	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/MultiplexerTest.java	/^    public MockBackendServer getBackend() {$/;"	m	class:MultiplexerTest
+getBootstrap	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/MockBackendServer.java	/^    private ServerBootstrap getBootstrap() {$/;"	m	class:MockBackendServer	file:
+getChannel	examples/curl/Curl.h	/^  muduo::net::Channel* getChannel() { return get_pointer(channel_); }$/;"	f	class:curl::Request
+getConnectionList	examples/asio/chat/server_threaded_efficient.cc	/^  ConnectionListPtr getConnectionList()$/;"	f	class:ChatServer	file:
+getContext	muduo/net/TcpConnection.h	/^  const boost::any& getContext() const$/;"	f	class:muduo::net::TcpConnection
+getCount	muduo/base/CountDownLatch.cc	/^int CountDownLatch::getCount() const$/;"	f	class:CountDownLatch
+getCurl	examples/curl/Curl.h	/^  CURL* getCurl() { return curl_; }$/;"	f	class:curl::Request
+getCurlm	examples/curl/Curl.h	/^  CURLM* getCurlm() { return curlm_; }$/;"	f	class:curl::Curl
+getEffectiveUrl	examples/curl/Curl.cc	/^const char* Request::getEffectiveUrl()$/;"	f	class:Request
+getEventLoopOfCurrentThread	muduo/net/EventLoop.cc	/^EventLoop* EventLoop::getEventLoopOfCurrentThread()$/;"	f	class:EventLoop
+getEventQueue	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/MultiplexerTest.java	/^    public EventQueue getEventQueue() {$/;"	m	class:MultiplexerTest
+getExpired	muduo/net/TimerQueue.cc	/^std::vector<TimerQueue::Entry> TimerQueue::getExpired(Timestamp now)$/;"	f	class:TimerQueue
+getGmt	muduo/base/tests/TimeZone_unittest.cc	/^time_t getGmt(const char* str)$/;"	f
+getGmt	muduo/base/tests/TimeZone_unittest.cc	/^time_t getGmt(int year, int month, int day,$/;"	f
+getHeader	muduo/net/http/HttpRequest.h	/^  string getHeader(const string& field) const$/;"	f	class:muduo::net::HttpRequest
+getItem	examples/memcached/server/MemcacheServer.cc	/^ConstItemPtr MemcacheServer::getItem(const ConstItemPtr& key) const$/;"	f	class:MemcacheServer
+getJulianDayNumber	muduo/base/Date.cc	/^int getJulianDayNumber(int year, int month, int day)$/;"	f	namespace:muduo::detail
+getLocalAddr	muduo/net/SocketsOps.cc	/^struct sockaddr_in sockets::getLocalAddr(int sockfd)$/;"	f	class:sockets
+getLogFileName	muduo/base/LogFile.cc	/^string LogFile::getLogFileName(const string& basename, time_t* now)$/;"	f	class:LogFile
+getLong	muduo/net/inspect/ProcessInspector.cc	/^long getLong(const string& procStatus, const char* key)$/;"	f
+getLoop	examples/curl/Curl.h	/^  muduo::net::EventLoop* getLoop() { return loop_; }$/;"	f	class:curl::Curl
+getLoop	muduo/net/TcpClient.h	/^  EventLoop* getLoop() const { return loop_; }$/;"	f	class:muduo::net::TcpClient
+getLoop	muduo/net/TcpConnection.h	/^  EventLoop* getLoop() const { return loop_; }$/;"	f	class:muduo::net::TcpConnection
+getLoop	muduo/net/TcpServer.h	/^  EventLoop* getLoop() const { return loop_; }$/;"	f	class:muduo::net::TcpServer
+getLoop	muduo/net/http/HttpServer.h	/^  EventLoop* getLoop() const { return server_.getLoop(); }$/;"	f	class:muduo::net::HttpServer
+getMutableContext	muduo/net/TcpConnection.h	/^  boost::any* getMutableContext()$/;"	f	class:muduo::net::TcpConnection
+getNextLoop	muduo/net/EventLoopThreadPool.cc	/^EventLoop* EventLoopThreadPool::getNextLoop()$/;"	f	class:EventLoopThreadPool
+getPeerAddr	muduo/net/SocketsOps.cc	/^struct sockaddr_in sockets::getPeerAddr(int sockfd)$/;"	f	class:sockets
+getPipeline	examples/filetransfer/loadtest/Client.java	/^        public ChannelPipeline getPipeline() throws Exception {$/;"	m	class:Client.PipelineFactory
+getProcessName	muduo/net/inspect/ProcessInspector.cc	/^string getProcessName(const string& procStatus)$/;"	f
+getPthreadMutex	muduo/base/Mutex.h	/^  pthread_mutex_t* getPthreadMutex() \/* non-const *\/$/;"	f	class:muduo::MutexLock
+getRedirectUrl	examples/curl/Curl.cc	/^const char* Request::getRedirectUrl()$/;"	f	class:Request
+getResponseCode	examples/curl/Curl.cc	/^int Request::getResponseCode()$/;"	f	class:Request
+getSeconds	examples/cdns/Resolver.cc	/^double getSeconds(struct timeval* tv)$/;"	f	namespace:__anon9
+getSockAddrInet	muduo/net/InetAddress.h	/^  const struct sockaddr_in& getSockAddrInet() const { return addr_; }$/;"	f	class:muduo::net::InetAddress
+getSocketError	muduo/net/SocketsOps.cc	/^int sockets::getSocketError(int sockfd)$/;"	f	class:sockets
+getSocketType	examples/cdns/Resolver.cc	/^const char* getSocketType(int type)$/;"	f	namespace:__anon9
+getStatField	muduo/net/inspect/ProcessInspector.cc	/^long getStatField(const string& procStat, int field)$/;"	f
+getString	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/DataEvent.java	/^    public String getString() {$/;"	m	class:DataEvent
+getTm	muduo/base/tests/TimeZone_unittest.cc	/^struct tm getTm(const char* str)$/;"	f
+getTm	muduo/base/tests/TimeZone_unittest.cc	/^struct tm getTm(int year, int month, int day,$/;"	f
+getTopic	examples/hub/hub.cc	/^  Topic& getTopic(const string& topic)$/;"	f	class:pubsub::PubSubServer	file:
+getUrl	examples/curl/Curl.cc	/^RequestPtr Curl::getUrl(muduo::StringPiece url)$/;"	f	class:Curl
+getUser	examples/twisted/finger/finger06.cc	/^string getUser(const string& user)$/;"	f
+getUser	examples/twisted/finger/finger07.cc	/^string getUser(const string& user)$/;"	f
+getVersion	muduo/net/http/HttpRequest.h	/^  Version getVersion() const$/;"	f	class:muduo::net::HttpRequest
+getYearMonthDay	muduo/base/Date.cc	/^struct Date::YearMonthDay getYearMonthDay(int julianDayNumber)$/;"	f	namespace:muduo::detail
+get_box_col	examples/sudoku/sudoku.cc	/^    int get_box_col(int box, int val)$/;"	f	class:SudokuSolver	file:
+get_col_col	examples/sudoku/sudoku.cc	/^    int get_col_col(int col, int val)$/;"	f	class:SudokuSolver	file:
+get_min_column	examples/sudoku/sudoku.cc	/^    Column* get_min_column()$/;"	f	class:SudokuSolver	file:
+get_row_col	examples/sudoku/sudoku.cc	/^    int get_row_col(int row, int val)$/;"	f	class:SudokuSolver	file:
+gettid	muduo/base/Thread.cc	/^pid_t gettid()$/;"	f	namespace:muduo::detail
+gmt	muduo/base/tests/TimeZone_unittest.cc	/^  const char* gmt;$/;"	m	struct:TestCase	file:
+gmtOffset	muduo/base/TimeZone.cc	/^  time_t gmtOffset;$/;"	m	struct:muduo::detail::Localtime	file:
+gmttime	muduo/base/TimeZone.cc	/^  time_t gmttime;$/;"	m	struct:muduo::detail::Transition	file:
+god	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/TestCase.java	/^    protected MultiplexerTest god;$/;"	f	class:TestCase
+google	muduo/net/protorpc/RpcChannel.h	/^namespace google {$/;"	n
+google	muduo/net/protorpc/RpcServer.h	/^namespace google {$/;"	n
+gotAll	muduo/net/http/HttpContext.h	/^  bool gotAll() const$/;"	f	class:muduo::net::HttpContext
+gotRequest_	examples/fastcgi/fastcgi.h	/^  bool gotRequest_;$/;"	m	class:FastCgiCodec
+got_	examples/protobuf/resolver/client.cc	/^  int got_;$/;"	m	class:RpcClient	file:
+gperfport	examples/memcached/server/MemcacheServer.h	/^    uint16_t gperfport;$/;"	m	struct:MemcacheServer::Options
+growth	muduo/net/inspect/PerformanceInspector.cc	/^string PerformanceInspector::growth(HttpRequest::Method, const Inspector::ArgList&)$/;"	f	class:PerformanceInspector
+handleClose	muduo/net/TcpConnection.cc	/^void TcpConnection::handleClose()$/;"	f	class:TcpConnection
+handleError	muduo/net/Connector.cc	/^void Connector::handleError()$/;"	f	class:Connector
+handleError	muduo/net/TcpConnection.cc	/^void TcpConnection::handleError()$/;"	f	class:TcpConnection
+handleEvent	muduo/net/Channel.cc	/^void Channel::handleEvent(Timestamp receiveTime)$/;"	f	class:Channel
+handleEventWithGuard	muduo/net/Channel.cc	/^void Channel::handleEventWithGuard(Timestamp receiveTime)$/;"	f	class:Channel
+handleRead	muduo/net/Acceptor.cc	/^void Acceptor::handleRead()$/;"	f	class:Acceptor
+handleRead	muduo/net/EventLoop.cc	/^void EventLoop::handleRead()$/;"	f	class:EventLoop
+handleRead	muduo/net/TcpConnection.cc	/^void TcpConnection::handleRead(Timestamp receiveTime)$/;"	f	class:TcpConnection
+handleRead	muduo/net/TimerQueue.cc	/^void TimerQueue::handleRead()$/;"	f	class:TimerQueue
+handleTimeout	examples/pingpong/client.cc	/^  void handleTimeout()$/;"	f	class:Client	file:
+handleWrite	muduo/net/Connector.cc	/^void Connector::handleWrite()$/;"	f	class:Connector
+handleWrite	muduo/net/TcpConnection.cc	/^void TcpConnection::handleWrite()$/;"	f	class:TcpConnection
+hasWritten	muduo/net/Buffer.h	/^  void hasWritten(size_t len)$/;"	f	class:muduo::net::Buffer
+has_trivial_assignment_operator	muduo/base/StringPiece.h	/^  typedef __true_type    has_trivial_assignment_operator;$/;"	t	struct:__type_traits
+has_trivial_copy_constructor	muduo/base/StringPiece.h	/^  typedef __true_type    has_trivial_copy_constructor;$/;"	t	struct:__type_traits
+has_trivial_default_constructor	muduo/base/StringPiece.h	/^  typedef __true_type    has_trivial_default_constructor;$/;"	t	struct:__type_traits
+has_trivial_destructor	muduo/base/StringPiece.h	/^  typedef __true_type    has_trivial_destructor;$/;"	t	struct:__type_traits
+hash	examples/memcached/server/Item.h	/^  size_t hash() const$/;"	f	class:Item
+hash_	examples/memcached/server/Item.h	/^  size_t         hash_;$/;"	m	class:Item
+hash_value	examples/idleconnection/echo.h	/^inline size_t hash_value(const boost::shared_ptr<T>& x)$/;"	f	namespace:boost
+hash_value	examples/wordcount/hash.h	/^inline std::size_t hash_value(const muduo::string& x)$/;"	f	namespace:boost
+headerCallback	examples/curl/Curl.cc	/^void Request::headerCallback(const char* buffer, int len)$/;"	f	class:Request
+headerCb_	examples/curl/Curl.h	/^  DataCallback headerCb_;$/;"	m	class:curl::Request
+headerData	examples/curl/Curl.cc	/^size_t Request::headerData(char* buffer, size_t size, size_t nmemb, void* userp)$/;"	f	class:Request
+headerOnly	examples/curl/Curl.cc	/^void Request::headerOnly()$/;"	f	class:Request
+headers	muduo/net/http/HttpRequest.h	/^  const std::map<string, string>& headers() const$/;"	f	class:muduo::net::HttpRequest
+headers	premake4.lua	/^    function headers(files)$/;"	f
+headers_	muduo/net/http/HttpRequest.h	/^  std::map<string, string> headers_;$/;"	m	class:muduo::net::HttpRequest
+headers_	muduo/net/http/HttpResponse.h	/^  std::map<string, string> headers_;$/;"	m	class:muduo::net::HttpResponse
+headersdir	premake4.lua	/^    function headersdir(dir)$/;"	f
+heap	muduo/net/inspect/PerformanceInspector.cc	/^string PerformanceInspector::heap(HttpRequest::Method, const Inspector::ArgList&)$/;"	f	class:PerformanceInspector
+helps_	muduo/net/inspect/Inspector.h	/^  std::map<string, HelpList> helps_;$/;"	m	class:muduo::net::Inspector
+highWaterMarkCallback_	muduo/net/TcpConnection.h	/^  HighWaterMarkCallback highWaterMarkCallback_;$/;"	m	class:muduo::net::TcpConnection
+highWaterMark_	muduo/net/TcpConnection.h	/^  size_t highWaterMark_;$/;"	m	class:muduo::net::TcpConnection
+holder_	muduo/base/Mutex.h	/^  pid_t holder_;$/;"	m	class:muduo::MutexLock
+host	examples/wordcount/slowsink.py	/^	host = sys.argv[2]$/;"	v
+host	examples/wordcount/slowsink.py	/^host = ''$/;"	v
+hostToNetwork16	muduo/net/Endian.h	/^inline uint16_t hostToNetwork16(uint16_t host16)$/;"	f	namespace:muduo::net::sockets
+hostToNetwork32	muduo/net/Endian.h	/^inline uint32_t hostToNetwork32(uint32_t host32)$/;"	f	namespace:muduo::net::sockets
+hostToNetwork64	muduo/net/Endian.h	/^inline uint64_t hostToNetwork64(uint64_t host64)$/;"	f	namespace:muduo::net::sockets
+hostname	muduo/base/ProcessInfo.cc	/^string ProcessInfo::hostname()$/;"	f	class:ProcessInfo
+hostport	muduo/net/TcpServer.h	/^  const string& hostport() const { return hostport_; }$/;"	f	class:muduo::net::TcpServer
+hostport_	muduo/net/TcpServer.h	/^  const string hostport_;$/;"	m	class:muduo::net::TcpServer
+howMuchTimeFromNow	muduo/net/TimerQueue.cc	/^struct timespec howMuchTimeFromNow(Timestamp when)$/;"	f	namespace:muduo::net::detail
+httpCallback_	muduo/net/http/HttpServer.h	/^  HttpCallback httpCallback_;$/;"	m	class:muduo::net::HttpServer
+id	examples/fastcgi/fastcgi.cc	/^  uint16_t id;$/;"	m	struct:FastCgiCodec::RecordHeader	file:
+id	examples/filetransfer/loadtest/Handler.java	/^    private int id;$/;"	f	class:Handler	file:
+id_	muduo/net/protorpc/RpcChannel.h	/^  AtomicInt64 id_;$/;"	m	class:muduo::net::RpcChannel
+idleFd_	muduo/net/Acceptor.h	/^  int idleFd_;$/;"	m	class:muduo::net::Acceptor
+idleSeconds_	examples/idleconnection/sortedlist.cc	/^  int idleSeconds_;$/;"	m	class:EchoServer	file:
+impl_	muduo/base/Logging.h	/^  Impl impl_;$/;"	m	class:muduo::Logger
+implicit_cast	muduo/base/Types.h	/^inline To implicit_cast(From const &f) {$/;"	f	namespace:muduo
+increment	muduo/base/Atomic.h	/^  void increment()$/;"	f	class:muduo::detail::AtomicIntegerT
+incrementAndGet	muduo/base/Atomic.h	/^  T incrementAndGet()$/;"	f	class:muduo::detail::AtomicIntegerT
+index	muduo/net/Channel.h	/^  int index() { return index_; }$/;"	f	class:muduo::net::Channel
+index_	muduo/net/Channel.h	/^  int        index_; \/\/ used by Poller.$/;"	m	class:muduo::net::Channel
+init	muduo/base/Singleton.h	/^  static void init()$/;"	f	class:muduo::Singleton
+init	muduo/base/Thread.cc	/^ThreadNameInitializer init;$/;"	m	namespace:muduo::detail	file:
+init	muduo/net/tests/EventLoopThreadPool_unittest.cc	/^void init(EventLoop* p)$/;"	f
+initLogLevel	muduo/base/Logging.cc	/^Logger::LogLevel initLogLevel()$/;"	f	namespace:muduo
+initObj	muduo/net/EventLoop.cc	/^IgnoreSigPipe initObj;$/;"	m	namespace:__anon4	file:
+initialize	examples/curl/Curl.cc	/^void Curl::initialize(Option opt)$/;"	f	class:Curl
+inout_	examples/sudoku/sudoku.cc	/^    int*    inout_;$/;"	m	class:SudokuSolver	file:
+inputBuffer	muduo/net/TcpConnection.h	/^  Buffer* inputBuffer()$/;"	f	class:muduo::net::TcpConnection
+inputBuffer_	muduo/net/TcpConnection.h	/^  Buffer inputBuffer_;$/;"	m	class:muduo::net::TcpConnection
+input_	examples/sudoku/client.cc	/^  InputPtr input_;$/;"	m	class:SudokuClient	file:
+insert	muduo/net/TimerQueue.cc	/^bool TimerQueue::insert(Timer* timer)$/;"	f	class:TimerQueue
+instance	muduo/base/Singleton.h	/^  static T& instance()$/;"	f	class:muduo::Singleton
+instance	muduo/base/ThreadLocalSingleton.h	/^  static T& instance()$/;"	f	class:muduo::ThreadLocalSingleton
+internalCapacity	muduo/net/Buffer.h	/^  size_t internalCapacity() const$/;"	f	class:muduo::net::Buffer
+interval_	muduo/net/Timer.h	/^  const double interval_;$/;"	m	class:muduo::net::Timer
+invalid	muduo/base/Timestamp.cc	/^Timestamp Timestamp::invalid()$/;"	f	class:Timestamp
+ipNetEndian	muduo/net/InetAddress.h	/^  uint32_t ipNetEndian() const { return addr_.sin_addr.s_addr; }$/;"	f	class:muduo::net::InetAddress
+isBinaryProtocol	examples/memcached/server/Session.cc	/^static bool isBinaryProtocol(uint8_t firstByte)$/;"	f	file:
+isDst	muduo/base/TimeZone.cc	/^  bool isDst;$/;"	m	struct:muduo::detail::Localtime	file:
+isEmpty	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/EventQueue.java	/^    public boolean isEmpty() {$/;"	m	class:EventQueue
+isFull	muduo/base/ThreadPool.cc	/^bool ThreadPool::isFull() const$/;"	f	class:ThreadPool
+isInLoopThread	muduo/net/EventLoop.h	/^  bool isInLoopThread() const { return threadId_ == CurrentThread::tid(); }$/;"	f	class:muduo::net::EventLoop
+isLeapYear	muduo/base/tests/Date_unittest.cc	/^int isLeapYear(int year)$/;"	f
+isLockedByThisThread	muduo/base/Mutex.h	/^  bool isLockedByThisThread() const$/;"	f	class:muduo::MutexLock
+isMainThread	muduo/base/Thread.cc	/^bool CurrentThread::isMainThread()$/;"	f	class:CurrentThread
+isNoneEvent	muduo/net/Channel.h	/^  bool isNoneEvent() const { return events_ == kNoneEvent; }$/;"	f	class:muduo::net::Channel
+isSelfConnect	muduo/net/SocketsOps.cc	/^bool sockets::isSelfConnect(int sockfd)$/;"	f	class:sockets
+isWriting	muduo/net/Channel.h	/^  bool isWriting() const { return events_ & kWriteEvent; }$/;"	f	class:muduo::net::Channel
+is_POD_type	muduo/base/StringPiece.h	/^  typedef __true_type    is_POD_type;$/;"	t	struct:__type_traits
+isdst	muduo/base/tests/TimeZone_unittest.cc	/^  bool isdst;$/;"	m	struct:TestCase	file:
+items	examples/memcached/server/MemcacheServer.h	/^    ItemMap items;$/;"	m	struct:MemcacheServer::MapWithLock
+iteration	muduo/net/EventLoop.h	/^  int64_t iteration() const { return iteration_; }$/;"	f	class:muduo::net::EventLoop
+iteration_	muduo/net/EventLoop.h	/^  int64_t iteration_;$/;"	m	class:muduo::net::EventLoop
+join	muduo/base/Thread.cc	/^int Thread::join()$/;"	f	class:Thread
+joinAll	muduo/base/tests/BlockingQueue_bench.cc	/^  void joinAll()$/;"	f	class:Bench
+joinAll	muduo/base/tests/BlockingQueue_test.cc	/^  void joinAll()$/;"	f	class:Test
+joinAll	muduo/base/tests/BoundedBlockingQueue_test.cc	/^  void joinAll()$/;"	f	class:Test
+joined_	muduo/base/Thread.h	/^  bool       joined_;$/;"	m	class:muduo::Thread
+julianDayNumber	muduo/base/Date.h	/^  int julianDayNumber() const { return julianDayNumber_; }$/;"	f	class:muduo::Date
+julianDayNumber_	muduo/base/Date.h	/^  int julianDayNumber_;$/;"	m	class:muduo::Date
+k200Ok	muduo/net/http/HttpResponse.h	/^    k200Ok = 200,$/;"	e	enum:muduo::net::HttpResponse::HttpStatusCode
+k301MovedPermanently	muduo/net/http/HttpResponse.h	/^    k301MovedPermanently = 301,$/;"	e	enum:muduo::net::HttpResponse::HttpStatusCode
+k400BadRequest	muduo/net/http/HttpResponse.h	/^    k400BadRequest = 400,$/;"	e	enum:muduo::net::HttpResponse::HttpStatusCode
+k404NotFound	muduo/net/http/HttpResponse.h	/^    k404NotFound = 404,$/;"	e	enum:muduo::net::HttpResponse::HttpStatusCode
+kAdd	examples/memcached/server/Item.h	/^    kAdd,$/;"	e	enum:Item::UpdatePolicy
+kAdded	muduo/net/poller/EPollPoller.cc	/^const int kAdded = 1;$/;"	m	namespace:__anon3	file:
+kAppend	examples/memcached/server/Item.h	/^    kAppend,$/;"	e	enum:Item::UpdatePolicy
+kAscii	examples/memcached/server/Session.h	/^    kAscii,$/;"	e	enum:Session::Protocol
+kAuto	examples/memcached/server/Session.h	/^    kAuto,$/;"	e	enum:Session::Protocol
+kBackend	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/EventSource.java	/^    kBackend, kClient$/;"	e	enum:EventSource	file:
+kBackendPort	examples/multiplexer/multiplexer.cc	/^const uint16_t kBackendPort = 9999;$/;"	v
+kBackendPort	examples/multiplexer/multiplexer_simple.cc	/^const uint16_t kBackendPort = 9999;$/;"	v
+kBinary	examples/memcached/server/Session.h	/^    kBinary,$/;"	e	enum:Session::Protocol
+kBox	examples/sudoku/sudoku.cc	/^const int kRow = 100, kCol = 200, kBox = 300;$/;"	v
+kBufSize	examples/filetransfer/download2.cc	/^const int kBufSize = 64*1024;$/;"	v
+kBufSize	examples/filetransfer/download3.cc	/^const int kBufSize = 64*1024;$/;"	v
+kBufferSize	muduo/base/FileUtil.h	/^    static const int kBufferSize = 65536;$/;"	m	class:muduo::FileUtil::SmallFile
+kCRLF	muduo/net/Buffer.cc	/^const char Buffer::kCRLF[] = "\\r\\n";$/;"	m	class:Buffer	file:
+kCRLF	muduo/net/Buffer.h	/^  static const char kCRLF[];$/;"	m	class:muduo::net::Buffer
+kCURLnossl	examples/curl/Curl.h	/^    kCURLnossl = 0,$/;"	e	enum:curl::Curl::Option
+kCURLssl	examples/curl/Curl.h	/^    kCURLssl   = 1,$/;"	e	enum:curl::Curl::Option
+kCas	examples/memcached/server/Item.h	/^    kCas,$/;"	e	enum:Item::UpdatePolicy
+kCells	examples/sudoku/sudoku.h	/^const int kCells = 81;$/;"	v
+kCheapPrepend	muduo/net/Buffer.cc	/^const size_t Buffer::kCheapPrepend;$/;"	m	class:Buffer	file:
+kCheapPrepend	muduo/net/Buffer.h	/^  static const size_t kCheapPrepend = 8;$/;"	m	class:muduo::net::Buffer
+kCheckSumError	examples/protobuf/codec/codec.h	/^    kCheckSumError,$/;"	e	enum:ProtobufCodec::ErrorCode
+kCheckSumError	muduo/net/protorpc/RpcCodec.h	/^    kCheckSumError,$/;"	e	enum:muduo::net::RpcCodec::ErrorCode
+kCheckSumErrorStr	examples/protobuf/codec/codec.cc	/^  const string kCheckSumErrorStr = "CheckSumError";$/;"	m	namespace:__anon8	file:
+kCheckSumErrorStr	muduo/net/protorpc/RpcCodec.cc	/^  const string kCheckSumErrorStr = "CheckSumError";$/;"	m	namespace:__anon6	file:
+kCheckTimeRoll_	muduo/base/LogFile.h	/^  const static int kCheckTimeRoll_ = 1024;$/;"	m	class:muduo::LogFile
+kClient	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/EventSource.java	/^    kBackend, kClient$/;"	e	enum:EventSource	file:
+kClientPort	examples/multiplexer/multiplexer.cc	/^const uint16_t kClientPort = 3333;$/;"	v
+kClientPort	examples/multiplexer/multiplexer_simple.cc	/^const uint16_t kClientPort = 3333;$/;"	v
+kClients	examples/filetransfer/loadtest/Client.java	/^    static final int kClients = 500;$/;"	f	class:Client
+kCol	examples/sudoku/sudoku.cc	/^const int kRow = 100, kCol = 200, kBox = 300;$/;"	v
+kConcurrent	examples/curl/download.cc	/^  const static int kConcurrent = 4;$/;"	m	class:Downloader	file:
+kConnected	muduo/net/Connector.h	/^  enum States { kDisconnected, kConnecting, kConnected };$/;"	e	enum:muduo::net::Connector::States
+kConnected	muduo/net/TcpConnection.h	/^  enum StateE { kDisconnected, kConnecting, kConnected, kDisconnecting };$/;"	e	enum:muduo::net::TcpConnection::StateE
+kConnecting	muduo/net/Connector.h	/^  enum States { kDisconnected, kConnecting, kConnected };$/;"	e	enum:muduo::net::Connector::States
+kConnecting	muduo/net/TcpConnection.h	/^  enum StateE { kDisconnected, kConnecting, kConnected, kDisconnecting };$/;"	e	enum:muduo::net::TcpConnection::StateE
+kContinue	examples/hub/codec.h	/^  kContinue,$/;"	e	enum:pubsub::ParseResult
+kCount	muduo/base/tests/Mutex_test.cc	/^const int kCount = 10*1000*1000;$/;"	v
+kDNSandHostsFile	examples/cdns/Resolver.h	/^    kDNSandHostsFile,$/;"	e	enum:cdns::Resolver::Option
+kDNSonly	examples/cdns/Resolver.h	/^    kDNSonly,$/;"	e	enum:cdns::Resolver::Option
+kDaysPerWeek	muduo/base/Date.h	/^  static const int kDaysPerWeek = 7;$/;"	m	class:muduo::Date
+kDebug	examples/cdns/Resolver.cc	/^const bool kDebug = false;$/;"	m	namespace:__anon9	file:
+kDelete	muduo/net/http/HttpRequest.h	/^    kInvalid, kGet, kPost, kHead, kPut, kDelete$/;"	e	enum:muduo::net::HttpRequest::Method
+kDeleted	muduo/net/poller/EPollPoller.cc	/^const int kDeleted = 2;$/;"	m	namespace:__anon3	file:
+kDiscardValue	examples/memcached/server/Session.h	/^    kDiscardValue,$/;"	e	enum:Session::State
+kDisconnected	muduo/net/Connector.h	/^  enum States { kDisconnected, kConnecting, kConnected };$/;"	e	enum:muduo::net::Connector::States
+kDisconnected	muduo/net/TcpConnection.h	/^  enum StateE { kDisconnected, kConnecting, kConnected, kDisconnecting };$/;"	e	enum:muduo::net::TcpConnection::StateE
+kDisconnecting	muduo/net/TcpConnection.h	/^  enum StateE { kDisconnected, kConnecting, kConnected, kDisconnecting };$/;"	e	enum:muduo::net::TcpConnection::StateE
+kError	examples/hub/codec.h	/^  kError,$/;"	e	enum:pubsub::ParseResult
+kExpectBody	muduo/net/http/HttpContext.h	/^    kExpectBody,$/;"	e	enum:muduo::net::HttpContext::HttpRequestParseState
+kExpectHeaders	muduo/net/http/HttpContext.h	/^    kExpectHeaders,$/;"	e	enum:muduo::net::HttpContext::HttpRequestParseState
+kExpectRequestLine	muduo/net/http/HttpContext.h	/^    kExpectRequestLine,$/;"	e	enum:muduo::net::HttpContext::HttpRequestParseState
+kFcgiAbortRequest	examples/fastcgi/fastcgi.cc	/^  kFcgiAbortRequest = 2,$/;"	e	enum:FcgiType	file:
+kFcgiAuthorizer	examples/fastcgi/fastcgi.cc	/^  kFcgiAuthorizer = 2,$/;"	e	enum:FcgiRole	file:
+kFcgiBeginRequest	examples/fastcgi/fastcgi.cc	/^  kFcgiBeginRequest = 1,$/;"	e	enum:FcgiType	file:
+kFcgiData	examples/fastcgi/fastcgi.cc	/^  kFcgiData = 8,$/;"	e	enum:FcgiType	file:
+kFcgiEndRequest	examples/fastcgi/fastcgi.cc	/^  kFcgiEndRequest = 3,$/;"	e	enum:FcgiType	file:
+kFcgiGetValues	examples/fastcgi/fastcgi.cc	/^  kFcgiGetValues = 9,$/;"	e	enum:FcgiType	file:
+kFcgiGetValuesResult	examples/fastcgi/fastcgi.cc	/^  kFcgiGetValuesResult = 10,$/;"	e	enum:FcgiType	file:
+kFcgiInvalid	examples/fastcgi/fastcgi.cc	/^  kFcgiInvalid = 0,$/;"	e	enum:FcgiType	file:
+kFcgiKeepConn	examples/fastcgi/fastcgi.cc	/^  kFcgiKeepConn = 1,$/;"	e	enum:FcgiConstant	file:
+kFcgiParams	examples/fastcgi/fastcgi.cc	/^  kFcgiParams = 4,$/;"	e	enum:FcgiType	file:
+kFcgiResponder	examples/fastcgi/fastcgi.cc	/^  kFcgiResponder = 1,$/;"	e	enum:FcgiRole	file:
+kFcgiStderr	examples/fastcgi/fastcgi.cc	/^  kFcgiStderr = 7,$/;"	e	enum:FcgiType	file:
+kFcgiStdin	examples/fastcgi/fastcgi.cc	/^  kFcgiStdin = 5,$/;"	e	enum:FcgiType	file:
+kFcgiStdout	examples/fastcgi/fastcgi.cc	/^  kFcgiStdout = 6,$/;"	e	enum:FcgiType	file:
+kGet	examples/memcached/client/bench.cc	/^    kGet,$/;"	e	enum:Client::Operation	file:
+kGet	muduo/net/http/HttpRequest.h	/^    kInvalid, kGet, kPost, kHead, kPut, kDelete$/;"	e	enum:muduo::net::HttpRequest::Method
+kGotAll	muduo/net/http/HttpContext.h	/^    kGotAll,$/;"	e	enum:muduo::net::HttpContext::HttpRequestParseState
+kHead	muduo/net/http/HttpRequest.h	/^    kInvalid, kGet, kPost, kHead, kPut, kDelete$/;"	e	enum:muduo::net::HttpRequest::Method
+kHeaderLen	examples/asio/chat/codec.h	/^  const static size_t kHeaderLen = sizeof(int32_t);$/;"	m	class:LengthHeaderCodec
+kHeaderLen	examples/multiplexer/demux.cc	/^const size_t kHeaderLen = 3;$/;"	v
+kHeaderLen	examples/multiplexer/multiplexer.cc	/^const size_t kHeaderLen = 3;$/;"	v
+kHeaderLen	examples/multiplexer/multiplexer_simple.cc	/^const size_t kHeaderLen = 3;$/;"	v
+kHeaderLen	examples/protobuf/codec/codec.h	/^  const static int kHeaderLen = sizeof(int32_t);$/;"	m	class:ProtobufCodec
+kHeaderLen	muduo/net/protorpc/RpcCodec.h	/^  const static int kHeaderLen = sizeof(int32_t);$/;"	m	class:muduo::net::RpcCodec
+kHttp10	muduo/net/http/HttpRequest.h	/^    kUnknown, kHttp10, kHttp11$/;"	e	enum:muduo::net::HttpRequest::Version
+kHttp11	muduo/net/http/HttpRequest.h	/^    kUnknown, kHttp10, kHttp11$/;"	e	enum:muduo::net::HttpRequest::Version
+kInaddrAny	muduo/net/InetAddress.cc	/^static const in_addr_t kInaddrAny = INADDR_ANY;$/;"	v	file:
+kInitEventListSize	muduo/net/poller/EPollPoller.h	/^  static const int kInitEventListSize = 16;$/;"	m	class:muduo::net::EPollPoller
+kInitRetryDelayMs	muduo/net/Connector.h	/^  static const int kInitRetryDelayMs = 500;$/;"	m	class:muduo::net::Connector
+kInitialSize	muduo/net/Buffer.cc	/^const size_t Buffer::kInitialSize;$/;"	m	class:Buffer	file:
+kInitialSize	muduo/net/Buffer.h	/^  static const size_t kInitialSize = 1024;$/;"	m	class:muduo::net::Buffer
+kInvalid	examples/memcached/server/Item.h	/^    kInvalid,$/;"	e	enum:Item::UpdatePolicy
+kInvalid	muduo/net/http/HttpRequest.h	/^    kInvalid, kGet, kPost, kHead, kPut, kDelete$/;"	e	enum:muduo::net::HttpRequest::Method
+kInvalidLength	examples/protobuf/codec/codec.h	/^    kInvalidLength,$/;"	e	enum:ProtobufCodec::ErrorCode
+kInvalidLength	muduo/net/protorpc/RpcCodec.h	/^    kInvalidLength,$/;"	e	enum:muduo::net::RpcCodec::ErrorCode
+kInvalidLengthStr	examples/protobuf/codec/codec.cc	/^  const string kInvalidLengthStr = "InvalidLength";$/;"	m	namespace:__anon8	file:
+kInvalidLengthStr	muduo/net/protorpc/RpcCodec.cc	/^  const string kInvalidLengthStr = "InvalidLength";$/;"	m	namespace:__anon6	file:
+kInvalidNameLen	examples/protobuf/codec/codec.h	/^    kInvalidNameLen,$/;"	e	enum:ProtobufCodec::ErrorCode
+kInvalidNameLen	muduo/net/protorpc/RpcCodec.h	/^    kInvalidNameLen,$/;"	e	enum:muduo::net::RpcCodec::ErrorCode
+kInvalidNameLenStr	examples/protobuf/codec/codec.cc	/^  const string kInvalidNameLenStr = "InvalidNameLen";$/;"	m	namespace:__anon8	file:
+kInvalidNameLenStr	muduo/net/protorpc/RpcCodec.cc	/^  const string kInvalidNameLenStr = "InvalidNameLen";$/;"	m	namespace:__anon6	file:
+kJulianDayOf1970_01_01	muduo/base/Date.cc	/^const int Date::kJulianDayOf1970_01_01 = detail::getJulianDayNumber(1970, 1, 1);$/;"	m	class:muduo::Date	file:
+kJulianDayOf1970_01_01	muduo/base/Date.h	/^  static const int kJulianDayOf1970_01_01;$/;"	m	class:muduo::Date
+kLargeBuffer	muduo/base/LogStream.h	/^const int kLargeBuffer = 4000*1000;$/;"	m	namespace:muduo::detail
+kListenPort	examples/multiplexer/demux.cc	/^const uint16_t kListenPort = 9999;$/;"	v
+kLogicalServerPort	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/MultiplexerTest.java	/^    private static final int kLogicalServerPort = 9999;$/;"	f	class:MultiplexerTest	file:
+kLongestKey	examples/memcached/server/Session.h	/^  static string kLongestKey;$/;"	m	class:Session
+kLongestKeySize	examples/memcached/server/Session.cc	/^const int kLongestKeySize = 250;$/;"	v
+kMB	examples/filetransfer/loadtest/Client.java	/^    static final int kMB = 1024 * 1024;$/;"	f	class:Client
+kMaxColumns	examples/sudoku/sudoku.cc	/^const int kMaxColumns = 400;$/;"	v
+kMaxConnections_	examples/maxconnection/echo.h	/^  const int kMaxConnections_;$/;"	m	class:EchoServer
+kMaxConns	examples/multiplexer/demux.cc	/^const int kMaxConns = 1;$/;"	v
+kMaxConns	examples/multiplexer/multiplexer.cc	/^const int kMaxConns = 10;  \/\/ 65535$/;"	v
+kMaxConns	examples/multiplexer/multiplexer_simple.cc	/^const int kMaxConns = 10;  \/\/ 65535$/;"	v
+kMaxHashSize	examples/wordcount/hasher.cc	/^const size_t kMaxHashSize = 10 * 1000 * 1000;$/;"	v
+kMaxLength	examples/filetransfer/loadtest/Client.java	/^        private final int kMaxLength;$/;"	f	class:Client.PipelineFactory	file:
+kMaxLength	examples/filetransfer/loadtest/Client.java	/^    static final int kMaxLength = 6 * kMB;$/;"	f	class:Client
+kMaxMessageLen	examples/protobuf/codec/codec.h	/^  const static int kMaxMessageLen = 64*1024*1024; \/\/ same as codec_stream.h kDefaultTotalBytesLimit$/;"	m	class:ProtobufCodec
+kMaxMessageLen	muduo/net/protorpc/RpcCodec.h	/^  const static int kMaxMessageLen = 64*1024*1024; \/\/ same as codec_stream.h kDefaultTotalBytesLimit$/;"	m	class:muduo::net::RpcCodec
+kMaxNodes	examples/sudoku/sudoku.cc	/^const int kMaxNodes = 1 + 81*4 + 9*9*9*4;$/;"	v
+kMaxNumericSize	muduo/base/LogStream.h	/^  static const int kMaxNumericSize = 32;$/;"	m	class:muduo::LogStream
+kMaxPacketLen	examples/multiplexer/demux.cc	/^const size_t kMaxPacketLen = 255;$/;"	v
+kMaxPacketLen	examples/multiplexer/multiplexer.cc	/^const size_t kMaxPacketLen = 255;$/;"	v
+kMaxPacketLen	examples/multiplexer/multiplexer_simple.cc	/^const size_t kMaxPacketLen = 255;$/;"	v
+kMaxRetryDelayMs	muduo/net/Connector.cc	/^const int Connector::kMaxRetryDelayMs;$/;"	m	class:Connector	file:
+kMaxRetryDelayMs	muduo/net/Connector.h	/^  static const int kMaxRetryDelayMs = 30*1000;$/;"	m	class:muduo::net::Connector
+kMicroSecondsPerSecond	muduo/base/Timestamp.h	/^  static const int kMicroSecondsPerSecond = 1000 * 1000;$/;"	m	class:muduo::Timestamp
+kMinLength	examples/filetransfer/loadtest/Client.java	/^        private final int kMinLength;$/;"	f	class:Client.PipelineFactory	file:
+kMinLength	examples/filetransfer/loadtest/Client.java	/^    static final int kMinLength = 1 * kMB;$/;"	f	class:Client
+kMinMessageLen	examples/protobuf/codec/codec.h	/^  const static int kMinMessageLen = 2*kHeaderLen + 2; \/\/ nameLen + typeName + checkSum$/;"	m	class:ProtobufCodec
+kMinMessageLen	muduo/net/protorpc/RpcCodec.h	/^  const static int kMinMessageLen = 2*kHeaderLen; \/\/ RPC0 + checkSum$/;"	m	class:muduo::net::RpcCodec
+kMonthsOfYear	muduo/base/tests/Date_unittest.cc	/^const int kMonthsOfYear = 12;$/;"	v
+kMultiplexerServerPort	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/MultiplexerTest.java	/^    private static final int kMultiplexerServerPort = 3333;$/;"	f	class:MultiplexerTest	file:
+kNew	muduo/net/poller/EPollPoller.cc	/^const int kNew = -1;$/;"	m	namespace:__anon3	file:
+kNewCommand	examples/memcached/server/Session.h	/^    kNewCommand,$/;"	e	enum:Session::State
+kNoError	examples/protobuf/codec/codec.h	/^    kNoError = 0,$/;"	e	enum:ProtobufCodec::ErrorCode
+kNoError	muduo/net/protorpc/RpcCodec.h	/^    kNoError = 0,$/;"	e	enum:muduo::net::RpcCodec::ErrorCode
+kNoErrorStr	examples/protobuf/codec/codec.cc	/^  const string kNoErrorStr = "NoError";$/;"	m	namespace:__anon8	file:
+kNoErrorStr	muduo/net/protorpc/RpcCodec.cc	/^  const string kNoErrorStr = "NoError";$/;"	m	namespace:__anon6	file:
+kNoReusePort	muduo/net/TcpServer.h	/^    kNoReusePort,$/;"	e	enum:muduo::net::TcpServer::Option
+kNoneEvent	muduo/net/Channel.cc	/^const int Channel::kNoneEvent = 0;$/;"	m	class:Channel	file:
+kNoneEvent	muduo/net/Channel.h	/^  static const int kNoneEvent;$/;"	m	class:muduo::net::Channel
+kParseError	examples/protobuf/codec/codec.h	/^    kParseError,$/;"	e	enum:ProtobufCodec::ErrorCode
+kParseError	muduo/net/protorpc/RpcCodec.h	/^    kParseError,$/;"	e	enum:muduo::net::RpcCodec::ErrorCode
+kParseErrorStr	examples/protobuf/codec/codec.cc	/^  const string kParseErrorStr = "ParseError";$/;"	m	namespace:__anon8	file:
+kParseErrorStr	muduo/net/protorpc/RpcCodec.cc	/^  const string kParseErrorStr = "ParseError";$/;"	m	namespace:__anon6	file:
+kPollTimeMs	muduo/net/EventLoop.cc	/^const int kPollTimeMs = 10000;$/;"	m	namespace:__anon4	file:
+kPost	muduo/net/http/HttpRequest.h	/^    kInvalid, kGet, kPost, kHead, kPut, kDelete$/;"	e	enum:muduo::net::HttpRequest::Method
+kPrepend	examples/memcached/server/Item.h	/^    kPrepend,$/;"	e	enum:Item::UpdatePolicy
+kPut	muduo/net/http/HttpRequest.h	/^    kInvalid, kGet, kPost, kHead, kPut, kDelete$/;"	e	enum:muduo::net::HttpRequest::Method
+kReadEvent	muduo/net/Channel.cc	/^const int Channel::kReadEvent = POLLIN | POLLPRI;$/;"	m	class:Channel	file:
+kReadEvent	muduo/net/Channel.h	/^  static const int kReadEvent;$/;"	m	class:muduo::net::Channel
+kReceiveValue	examples/memcached/server/Session.h	/^    kReceiveValue,$/;"	e	enum:Session::State
+kRecordHeader	examples/fastcgi/fastcgi.cc	/^const unsigned FastCgiCodec::kRecordHeader = static_cast<unsigned>(sizeof(FastCgiCodec::RecordHeader));$/;"	m	class:FastCgiCodec	file:
+kRecordHeader	examples/fastcgi/fastcgi.h	/^  const static unsigned kRecordHeader;$/;"	m	class:FastCgiCodec
+kReplace	examples/memcached/server/Item.h	/^    kReplace,$/;"	e	enum:Item::UpdatePolicy
+kRequests	examples/protobuf/rpcbench/client.cc	/^static const int kRequests = 50000;$/;"	v	file:
+kReusePort	muduo/net/TcpServer.h	/^    kReusePort,$/;"	e	enum:muduo::net::TcpServer::Option
+kRollPerSeconds_	muduo/base/LogFile.h	/^  const static int kRollPerSeconds_ = 60*60*24;$/;"	m	class:muduo::LogFile
+kRollSize	muduo/base/tests/AsyncLogging_test.cc	/^int kRollSize = 500*1000*1000;$/;"	v
+kRow	examples/sudoku/sudoku.cc	/^const int kRow = 100, kCol = 200, kBox = 300;$/;"	v
+kSecondsPerDay	muduo/base/TimeZone.cc	/^const int kSecondsPerDay = 24*60*60;$/;"	m	namespace:muduo	file:
+kSet	examples/memcached/client/bench.cc	/^    kSet,$/;"	e	enum:Client::Operation	file:
+kSet	examples/memcached/server/Item.h	/^    kSet,$/;"	e	enum:Item::UpdatePolicy
+kShards	examples/memcached/server/MemcacheServer.h	/^  const static int kShards = 4096;$/;"	m	class:MemcacheServer
+kSmallBuffer	muduo/base/LogStream.h	/^const int kSmallBuffer = 4000;$/;"	m	namespace:muduo::detail
+kSocksPort	examples/multiplexer/demux.cc	/^const uint16_t kSocksPort = 7777;$/;"	v
+kSuccess	examples/hub/codec.h	/^  kSuccess,$/;"	e	enum:pubsub::ParseResult
+kUnknown	muduo/net/http/HttpRequest.h	/^    kUnknown, kHttp10, kHttp11$/;"	e	enum:muduo::net::HttpRequest::Version
+kUnknown	muduo/net/http/HttpResponse.h	/^    kUnknown,$/;"	e	enum:muduo::net::HttpResponse::HttpStatusCode
+kUnknownErrorStr	examples/protobuf/codec/codec.cc	/^  const string kUnknownErrorStr = "UnknownError";$/;"	m	namespace:__anon8	file:
+kUnknownErrorStr	muduo/net/protorpc/RpcCodec.cc	/^  const string kUnknownErrorStr = "UnknownError";$/;"	m	namespace:__anon6	file:
+kUnknownMessageType	examples/protobuf/codec/codec.h	/^    kUnknownMessageType,$/;"	e	enum:ProtobufCodec::ErrorCode
+kUnknownMessageType	muduo/net/protorpc/RpcCodec.h	/^    kUnknownMessageType,$/;"	e	enum:muduo::net::RpcCodec::ErrorCode
+kUnknownMessageTypeStr	examples/protobuf/codec/codec.cc	/^  const string kUnknownMessageTypeStr = "UnknownMessageType";$/;"	m	namespace:__anon8	file:
+kUnknownMessageTypeStr	muduo/net/protorpc/RpcCodec.cc	/^  const string kUnknownMessageTypeStr = "UnknownMessageType";$/;"	m	namespace:__anon6	file:
+kWriteEvent	muduo/net/Channel.cc	/^const int Channel::kWriteEvent = POLLOUT;$/;"	m	class:Channel	file:
+kWriteEvent	muduo/net/Channel.h	/^  static const int kWriteEvent;$/;"	m	class:muduo::net::Channel
+keepConn_	examples/fastcgi/fastcgi.h	/^  bool keepConn_;$/;"	m	class:FastCgiCodec
+key	examples/memcached/server/Item.h	/^  muduo::StringPiece key() const$/;"	f	class:Item
+keylen_	examples/memcached/server/Item.h	/^  int            keylen_;$/;"	m	class:Item
+keys_	examples/memcached/client/bench.cc	/^  const int keys_;$/;"	m	class:Client	file:
+lastFlush_	muduo/base/LogFile.h	/^  time_t lastFlush_;$/;"	m	class:muduo::LogFile
+lastPubTime_	examples/hub/hub.cc	/^  Timestamp lastPubTime_;$/;"	m	class:pubsub::Topic	file:
+lastReceiveTime	examples/idleconnection/sortedlist.cc	/^    Timestamp lastReceiveTime;$/;"	m	struct:EchoServer::Node	file:
+lastRoll_	muduo/base/LogFile.h	/^  time_t lastRoll_;$/;"	m	class:muduo::LogFile
+last_	examples/memcached/server/Session.cc	/^  Tokenizer::iterator last_;;$/;"	m	struct:Session::Reader	file:
+latch	examples/filetransfer/loadtest/Client.java	/^        private final CountDownLatch latch;$/;"	f	class:Client.PipelineFactory	file:
+latch	examples/filetransfer/loadtest/Handler.java	/^    private CountDownLatch latch;$/;"	f	class:Handler	file:
+latch	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/MockBackendServer.java	/^    private final CountDownLatch latch;$/;"	f	class:MockBackendServer	file:
+latch	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/MockClient.java	/^    private MyCountDownLatch latch;$/;"	f	class:MockClient	file:
+latch	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/MultiplexerTest.java	/^    private MyCountDownLatch latch;$/;"	f	class:MultiplexerTest	file:
+latch_	muduo/base/AsyncLogging.h	/^  muduo::CountDownLatch latch_;$/;"	m	class:muduo::AsyncLogging
+latch_	muduo/base/tests/BlockingQueue_bench.cc	/^  muduo::CountDownLatch latch_;$/;"	m	class:Bench	file:
+latch_	muduo/base/tests/BlockingQueue_test.cc	/^  muduo::CountDownLatch latch_;$/;"	m	class:Test	file:
+latch_	muduo/base/tests/BoundedBlockingQueue_test.cc	/^  muduo::CountDownLatch latch_;$/;"	m	class:Test	file:
+left	examples/sudoku/sudoku.cc	/^    Node* left;$/;"	m	struct:Node	file:
+len_	muduo/base/Logging.cc	/^  const unsigned len_;$/;"	m	class:muduo::T	file:
+length	examples/fastcgi/fastcgi.cc	/^  uint16_t length;$/;"	m	struct:FastCgiCodec::RecordHeader	file:
+length	muduo/base/LogStream.h	/^  int length() const { return length_; }$/;"	f	class:muduo::Fmt
+length	muduo/base/LogStream.h	/^  int length() const { return static_cast<int>(cur_ - data_); }$/;"	f	class:muduo::detail::FixedBuffer
+length_	examples/curl/download.cc	/^  int64_t length_;$/;"	m	class:Downloader	file:
+length_	muduo/base/LogStream.h	/^  int length_;$/;"	m	class:muduo::Fmt
+length_	muduo/base/StringPiece.h	/^  int           length_;$/;"	m	class:muduo::StringPiece
+level_	muduo/base/Logging.h	/^  LogLevel level_;$/;"	m	class:muduo::Logger::Impl
+line_	muduo/base/Logging.h	/^  int line_;$/;"	m	class:muduo::Logger::Impl
+listen	muduo/net/Acceptor.cc	/^void Acceptor::listen()$/;"	f	class:Acceptor
+listen	muduo/net/Socket.cc	/^void Socket::listen()$/;"	f	class:Socket
+listenOrDie	muduo/net/SocketsOps.cc	/^void sockets::listenOrDie(int sockfd)$/;"	f	class:sockets
+listen_address	examples/wordcount/slowsink.py	/^	listen_address = ("", port)$/;"	v
+listener	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/MockBackendServer.java	/^    private Channel listener;$/;"	f	class:MockBackendServer	file:
+listenning	muduo/net/Acceptor.h	/^  bool listenning() const { return listenning_; }$/;"	f	class:muduo::net::Acceptor
+listenning_	muduo/net/Acceptor.h	/^  bool listenning_;$/;"	m	class:muduo::net::Acceptor
+local	muduo/base/tests/TimeZone_unittest.cc	/^  const char* local;$/;"	m	struct:TestCase	file:
+localAddr_	muduo/net/TcpConnection.h	/^  InetAddress localAddr_;$/;"	m	class:muduo::net::TcpConnection
+localAddress	muduo/net/TcpConnection.h	/^  const InetAddress& localAddress() { return localAddr_; }$/;"	f	class:muduo::net::TcpConnection
+localtime	muduo/base/TimeZone.cc	/^  time_t localtime;$/;"	m	struct:muduo::detail::Transition	file:
+localtimeIdx	muduo/base/TimeZone.cc	/^  int localtimeIdx;$/;"	m	struct:muduo::detail::Transition	file:
+localtimes	muduo/base/TimeZone.cc	/^  vector<detail::Localtime> localtimes;$/;"	m	struct:TimeZone::Data	file:
+lock	muduo/base/Mutex.h	/^  void lock()$/;"	f	class:muduo::MutexLock
+logHup_	muduo/net/Channel.h	/^  bool       logHup_;$/;"	m	class:muduo::net::Channel
+logInThread	muduo/base/tests/Logging_test.cc	/^void logInThread()$/;"	f
+logLevel	muduo/base/Logging.h	/^inline Logger::LogLevel Logger::logLevel()$/;"	f	class:muduo::Logger
+logger	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/MockBackendServer.java	/^    private static final Logger logger = LoggerFactory.getLogger("MockBackendServer");$/;"	f	class:MockBackendServer	file:
+logger	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/MockClient.java	/^    private static final Logger logger = LoggerFactory.getLogger("MockClient");$/;"	f	class:MockClient	file:
+logger	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/MultiplexerTest.java	/^    private static final Logger logger = LoggerFactory.getLogger("MultiplexerTest");$/;"	f	class:MultiplexerTest	file:
+loop	muduo/net/EventLoop.cc	/^void EventLoop::loop()$/;"	f	class:EventLoop
+loop1_	examples/asio/tutorial/timer5/timer.cc	/^  muduo::net::EventLoop* loop1_;$/;"	m	class:Printer	file:
+loop1_	examples/asio/tutorial/timer6/timer.cc	/^  muduo::net::EventLoop* loop1_;$/;"	m	class:Printer	file:
+loop2_	examples/asio/tutorial/timer5/timer.cc	/^  muduo::net::EventLoop* loop2_;$/;"	m	class:Printer	file:
+loop2_	examples/asio/tutorial/timer6/timer.cc	/^  muduo::net::EventLoop* loop2_;$/;"	m	class:Printer	file:
+loopThread_	examples/wordcount/hasher.cc	/^  EventLoopThread loopThread_;$/;"	m	class:WordCountSender	file:
+loop_	examples/asio/chat/loadtest.cc	/^  EventLoop* loop_;$/;"	m	class:ChatClient	file:
+loop_	examples/asio/tutorial/timer4/timer.cc	/^  muduo::net::EventLoop* loop_;$/;"	m	class:Printer	file:
+loop_	examples/cdns/Resolver.h	/^  muduo::net::EventLoop* loop_;$/;"	m	class:cdns::Resolver
+loop_	examples/curl/Curl.h	/^  muduo::net::EventLoop* loop_;$/;"	m	class:curl::Curl
+loop_	examples/curl/download.cc	/^  EventLoop* loop_;$/;"	m	class:Downloader	file:
+loop_	examples/hub/hub.cc	/^  EventLoop* loop_;$/;"	m	class:pubsub::PubSubServer	file:
+loop_	examples/memcached/server/MemcacheServer.h	/^  muduo::net::EventLoop* loop_;  \/\/ not own$/;"	m	class:MemcacheServer
+loop_	examples/multiplexer/demux.cc	/^  EventLoop* loop_;$/;"	m	class:DemuxServer	file:
+loop_	examples/netty/discard/client.cc	/^  EventLoop* loop_;$/;"	m	class:DiscardClient	file:
+loop_	examples/netty/echo/client.cc	/^  EventLoop* loop_;$/;"	m	class:EchoClient	file:
+loop_	examples/pingpong/client.cc	/^  EventLoop* loop_;$/;"	m	class:Client	file:
+loop_	examples/protobuf/codec/client.cc	/^  EventLoop* loop_;$/;"	m	class:QueryClient	file:
+loop_	examples/protobuf/resolver/client.cc	/^  EventLoop* loop_;$/;"	m	class:RpcClient	file:
+loop_	examples/protobuf/rpc/client.cc	/^  EventLoop* loop_;$/;"	m	class:RpcClient	file:
+loop_	examples/simple/chargenclient/chargenclient.cc	/^  EventLoop* loop_;$/;"	m	class:ChargenClient	file:
+loop_	examples/simple/timeclient/timeclient.cc	/^  EventLoop* loop_;$/;"	m	class:TimeClient	file:
+loop_	examples/wordcount/hasher.cc	/^  EventLoop* loop_;$/;"	m	class:WordCountSender	file:
+loop_	examples/wordcount/receiver.cc	/^  EventLoop* loop_;$/;"	m	class:WordCountReceiver	file:
+loop_	muduo/net/Acceptor.h	/^  EventLoop* loop_;$/;"	m	class:muduo::net::Acceptor
+loop_	muduo/net/Channel.h	/^  EventLoop* loop_;$/;"	m	class:muduo::net::Channel
+loop_	muduo/net/Connector.h	/^  EventLoop* loop_;$/;"	m	class:muduo::net::Connector
+loop_	muduo/net/EventLoopThread.h	/^  EventLoop* loop_;$/;"	m	class:muduo::net::EventLoopThread
+loop_	muduo/net/TcpClient.h	/^  EventLoop* loop_;$/;"	m	class:muduo::net::TcpClient
+loop_	muduo/net/TcpConnection.h	/^  EventLoop* loop_;$/;"	m	class:muduo::net::TcpConnection
+loop_	muduo/net/TcpServer.h	/^  EventLoop* loop_;  \/\/ the acceptor loop$/;"	m	class:muduo::net::TcpServer
+loop_	muduo/net/TimerQueue.h	/^  EventLoop* loop_;$/;"	m	class:muduo::net::TimerQueue
+loop_	muduo/net/tests/EchoClient_unittest.cc	/^  EventLoop* loop_;$/;"	m	class:EchoClient	file:
+loop_	muduo/net/tests/EchoServer_unittest.cc	/^  EventLoop* loop_;$/;"	m	class:EchoServer	file:
+looping_	muduo/net/EventLoop.h	/^  bool looping_; \/* atomic *\/$/;"	m	class:muduo::net::EventLoop
+loops_	examples/asio/chat/server_threaded_highperformance.cc	/^  std::set<EventLoop*> loops_;$/;"	m	class:ChatServer	file:
+loops_	muduo/net/EventLoopThreadPool.h	/^  std::vector<EventLoop*> loops_;$/;"	m	class:muduo::net::EventLoopThreadPool
+main	examples/asio/chat/client.cc	/^int main(int argc, char* argv[])$/;"	f
+main	examples/asio/chat/loadtest.cc	/^int main(int argc, char* argv[])$/;"	f
+main	examples/asio/chat/server.cc	/^int main(int argc, char* argv[])$/;"	f
+main	examples/asio/chat/server_threaded.cc	/^int main(int argc, char* argv[])$/;"	f
+main	examples/asio/chat/server_threaded_efficient.cc	/^int main(int argc, char* argv[])$/;"	f
+main	examples/asio/chat/server_threaded_highperformance.cc	/^int main(int argc, char* argv[])$/;"	f
+main	examples/asio/tutorial/timer2/timer.cc	/^int main()$/;"	f
+main	examples/asio/tutorial/timer3/timer.cc	/^int main()$/;"	f
+main	examples/asio/tutorial/timer4/timer.cc	/^int main()$/;"	f
+main	examples/asio/tutorial/timer5/timer.cc	/^int main()$/;"	f
+main	examples/asio/tutorial/timer6/timer.cc	/^int main()$/;"	f
+main	examples/cdns/dns.cc	/^int main(int argc, char* argv[])$/;"	f
+main	examples/curl/download.cc	/^int main(int argc, char* argv[])$/;"	f
+main	examples/curl/mcurl.cc	/^int main(int argc, char* argv[])$/;"	f
+main	examples/fastcgi/fastcgi_test.cc	/^int main()$/;"	f
+main	examples/filetransfer/download.cc	/^int main(int argc, char* argv[])$/;"	f
+main	examples/filetransfer/download2.cc	/^int main(int argc, char* argv[])$/;"	f
+main	examples/filetransfer/download3.cc	/^int main(int argc, char* argv[])$/;"	f
+main	examples/filetransfer/loadtest/Client.java	/^    public static void main(String[] args) throws Exception {$/;"	m	class:Client
+main	examples/hub/hub.cc	/^int main(int argc, char* argv[])$/;"	f
+main	examples/hub/pub.cc	/^int main(int argc, char* argv[])$/;"	f
+main	examples/hub/sub.cc	/^int main(int argc, char* argv[])$/;"	f
+main	examples/idleconnection/main.cc	/^int main(int argc, char* argv[])$/;"	f
+main	examples/idleconnection/sortedlist.cc	/^int main(int argc, char* argv[])$/;"	f
+main	examples/maxconnection/main.cc	/^int main(int argc, char* argv[])$/;"	f
+main	examples/memcached/client/bench.cc	/^int main(int argc, char* argv[])$/;"	f
+main	examples/memcached/server/footprint_test.cc	/^int main(int argc, char* argv[])$/;"	f
+main	examples/memcached/server/server.cc	/^int main(int argc, char* argv[])$/;"	f
+main	examples/multiplexer/demux.cc	/^int main(int argc, char* argv[])$/;"	f
+main	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/MultiplexerTest.java	/^    public static void main(String[] args) {$/;"	m	class:MultiplexerTest
+main	examples/multiplexer/multiplexer.cc	/^int main(int argc, char* argv[])$/;"	f
+main	examples/multiplexer/multiplexer_simple.cc	/^int main(int argc, char* argv[])$/;"	f
+main	examples/netty/discard/client.cc	/^int main(int argc, char* argv[])$/;"	f
+main	examples/netty/discard/server.cc	/^int main(int argc, char* argv[])$/;"	f
+main	examples/netty/echo/client.cc	/^int main(int argc, char* argv[])$/;"	f
+main	examples/netty/echo/server.cc	/^int main(int argc, char* argv[])$/;"	f
+main	examples/netty/uptime/uptime.cc	/^int main(int argc, char* argv[])$/;"	f
+main	examples/pingpong/bench.cc	/^int main(int argc, char* argv[])$/;"	f
+main	examples/pingpong/client.cc	/^int main(int argc, char* argv[])$/;"	f
+main	examples/pingpong/server.cc	/^int main(int argc, char* argv[])$/;"	f
+main	examples/protobuf/codec/client.cc	/^int main(int argc, char* argv[])$/;"	f
+main	examples/protobuf/codec/codec_test.cc	/^int main()$/;"	f
+main	examples/protobuf/codec/dispatcher_lite_test.cc	/^int main()$/;"	f
+main	examples/protobuf/codec/dispatcher_test.cc	/^int main()$/;"	f
+main	examples/protobuf/codec/server.cc	/^int main(int argc, char* argv[])$/;"	f
+main	examples/protobuf/resolver/client.cc	/^int main(int argc, char* argv[])$/;"	f
+main	examples/protobuf/resolver/server.cc	/^int main()$/;"	f
+main	examples/protobuf/rpc/client.cc	/^int main(int argc, char* argv[])$/;"	f
+main	examples/protobuf/rpc/server.cc	/^int main()$/;"	f
+main	examples/protobuf/rpcbench/client.cc	/^int main(int argc, char* argv[])$/;"	f
+main	examples/protobuf/rpcbench/server.cc	/^int main()$/;"	f
+main	examples/roundtrip/roundtrip.cc	/^int main(int argc, char* argv[])$/;"	f
+main	examples/roundtrip/roundtrip_udp.cc	/^int main(int argc, char* argv[])$/;"	f
+main	examples/shorturl/shorturl.cc	/^int main(int argc, char* argv[])$/;"	f
+main	examples/simple/allinone/allinone.cc	/^int main()$/;"	f
+main	examples/simple/chargen/main.cc	/^int main()$/;"	f
+main	examples/simple/chargenclient/chargenclient.cc	/^int main(int argc, char* argv[])$/;"	f
+main	examples/simple/daytime/main.cc	/^int main()$/;"	f
+main	examples/simple/discard/main.cc	/^int main()$/;"	f
+main	examples/simple/echo/main.cc	/^int main()$/;"	f
+main	examples/simple/time/main.cc	/^int main()$/;"	f
+main	examples/simple/timeclient/timeclient.cc	/^int main(int argc, char* argv[])$/;"	f
+main	examples/socks4a/socks4a.cc	/^int main(int argc, char* argv[])$/;"	f
+main	examples/socks4a/tcprelay.cc	/^int main(int argc, char* argv[])$/;"	f
+main	examples/sudoku/client.cc	/^int main(int argc, char* argv[])$/;"	f
+main	examples/sudoku/server_basic.cc	/^int main(int argc, char* argv[])$/;"	f
+main	examples/sudoku/server_multiloop.cc	/^int main(int argc, char* argv[])$/;"	f
+main	examples/sudoku/server_threadpool.cc	/^int main(int argc, char* argv[])$/;"	f
+main	examples/twisted/finger/finger01.cc	/^int main()$/;"	f
+main	examples/twisted/finger/finger02.cc	/^int main()$/;"	f
+main	examples/twisted/finger/finger03.cc	/^int main()$/;"	f
+main	examples/twisted/finger/finger04.cc	/^int main()$/;"	f
+main	examples/twisted/finger/finger05.cc	/^int main()$/;"	f
+main	examples/twisted/finger/finger06.cc	/^int main()$/;"	f
+main	examples/twisted/finger/finger07.cc	/^int main()$/;"	f
+main	examples/wordcount/hasher.cc	/^int main(int argc, char* argv[])$/;"	f
+main	examples/wordcount/receiver.cc	/^int main(int argc, char* argv[])$/;"	f
+main	examples/zeromq/local_lat.cc	/^int main(int argc, char* argv[])$/;"	f
+main	examples/zeromq/remote_lat.cc	/^int main(int argc, char* argv[])$/;"	f
+main	muduo/base/tests/AsyncLogging_test.cc	/^int main(int argc, char* argv[])$/;"	f
+main	muduo/base/tests/Atomic_unittest.cc	/^int main()$/;"	f
+main	muduo/base/tests/BlockingQueue_bench.cc	/^int main(int argc, char* argv[])$/;"	f
+main	muduo/base/tests/BlockingQueue_test.cc	/^int main()$/;"	f
+main	muduo/base/tests/BoundedBlockingQueue_test.cc	/^int main()$/;"	f
+main	muduo/base/tests/Date_unittest.cc	/^int main()$/;"	f
+main	muduo/base/tests/Exception_test.cc	/^int main()$/;"	f
+main	muduo/base/tests/FileUtil_test.cc	/^int main()$/;"	f
+main	muduo/base/tests/Fork_test.cc	/^int main()$/;"	f
+main	muduo/base/tests/LogFile_test.cc	/^int main(int argc, char* argv[])$/;"	f
+main	muduo/base/tests/LogStream_bench.cc	/^int main()$/;"	f
+main	muduo/base/tests/Logging_test.cc	/^int main()$/;"	f
+main	muduo/base/tests/Mutex_test.cc	/^int main()$/;"	f
+main	muduo/base/tests/ProcessInfo_test.cc	/^int main()$/;"	f
+main	muduo/base/tests/SingletonThreadLocal_test.cc	/^int main()$/;"	f
+main	muduo/base/tests/Singleton_test.cc	/^int main()$/;"	f
+main	muduo/base/tests/ThreadLocalSingleton_test.cc	/^int main()$/;"	f
+main	muduo/base/tests/ThreadLocal_test.cc	/^int main()$/;"	f
+main	muduo/base/tests/ThreadPool_test.cc	/^int main()$/;"	f
+main	muduo/base/tests/Thread_bench.cc	/^int main(int argc, char* argv[])$/;"	f
+main	muduo/base/tests/Thread_test.cc	/^int main()$/;"	f
+main	muduo/base/tests/TimeZone_unittest.cc	/^int main()$/;"	f
+main	muduo/base/tests/Timestamp_unittest.cc	/^int main()$/;"	f
+main	muduo/net/http/tests/HttpServer_test.cc	/^int main(int argc, char* argv[])$/;"	f
+main	muduo/net/inspect/tests/Inspector_test.cc	/^int main()$/;"	f
+main	muduo/net/tests/EchoClient_unittest.cc	/^int main(int argc, char* argv[])$/;"	f
+main	muduo/net/tests/EchoServer_unittest.cc	/^int main(int argc, char* argv[])$/;"	f
+main	muduo/net/tests/EventLoopThreadPool_unittest.cc	/^int main()$/;"	f
+main	muduo/net/tests/EventLoopThread_unittest.cc	/^int main()$/;"	f
+main	muduo/net/tests/EventLoop_unittest.cc	/^int main()$/;"	f
+main	muduo/net/tests/TcpClient_reg1.cc	/^int main(int argc, char* argv[])$/;"	f
+main	muduo/net/tests/TimerQueue_unittest.cc	/^int main()$/;"	f
+makeItem	examples/memcached/server/Item.h	/^  static ItemPtr makeItem(StringPiece keyArg,$/;"	f	class:Item
+makeMessage	examples/hub/hub.cc	/^  string makeMessage()$/;"	f	class:pubsub::Topic	file:
+makeSpace	muduo/net/Buffer.h	/^  void makeSpace(size_t len)$/;"	f	class:muduo::net::Buffer
+maxLength	examples/filetransfer/loadtest/Handler.java	/^    private final int maxLength;$/;"	f	class:Handler	file:
+maxOpenFiles	muduo/base/ProcessInfo.cc	/^int ProcessInfo::maxOpenFiles()$/;"	f	class:ProcessInfo
+maxQueueSize_	muduo/base/ThreadPool.h	/^  size_t maxQueueSize_;$/;"	m	class:muduo::ThreadPool
+memberFunc	muduo/base/tests/Thread_test.cc	/^  void memberFunc()$/;"	f	class:Foo
+memberFunc2	muduo/base/tests/Thread_test.cc	/^  void memberFunc2(const std::string& text)$/;"	f	class:Foo
+memhistogram	muduo/net/inspect/PerformanceInspector.cc	/^string PerformanceInspector::memhistogram(HttpRequest::Method, const Inspector::ArgList&)$/;"	f	class:PerformanceInspector
+memstat	examples/socks4a/tcprelay.cc	/^void memstat()$/;"	f
+memstats	muduo/net/inspect/PerformanceInspector.cc	/^string PerformanceInspector::memstats(HttpRequest::Method, const Inspector::ArgList&)$/;"	f	class:PerformanceInspector
+message	examples/pingpong/client.cc	/^  const string& message() const$/;"	f	class:Client
+messageCallback_	examples/asio/chat/codec.h	/^  StringMessageCallback messageCallback_;$/;"	m	class:LengthHeaderCodec
+messageCallback_	examples/protobuf/codec/codec.h	/^  ProtobufMessageCallback messageCallback_;$/;"	m	class:ProtobufCodec
+messageCallback_	muduo/net/TcpClient.h	/^  MessageCallback messageCallback_;$/;"	m	class:muduo::net::TcpClient
+messageCallback_	muduo/net/TcpConnection.h	/^  MessageCallback messageCallback_;$/;"	m	class:muduo::net::TcpConnection
+messageCallback_	muduo/net/TcpServer.h	/^  MessageCallback messageCallback_;$/;"	m	class:muduo::net::TcpServer
+messageCallback_	muduo/net/protorpc/RpcCodec.h	/^  ProtobufMessageCallback messageCallback_;$/;"	m	class:muduo::net::RpcCodec
+messageReceived	examples/filetransfer/loadtest/Handler.java	/^    public void messageReceived(ChannelHandlerContext ctx, MessageEvent e) throws Exception {$/;"	m	class:Handler
+messageReceived	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/MockBackendServer.java	/^        public void messageReceived(ChannelHandlerContext ctx, MessageEvent e)$/;"	m	class:MockBackendServer.Handler
+messageReceived	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/MockClient.java	/^        public void messageReceived(ChannelHandlerContext ctx, MessageEvent e)$/;"	m	class:MockClient.Handler
+messageToSend	examples/protobuf/codec/client.cc	/^google::protobuf::Message* messageToSend;$/;"	v
+message_	examples/netty/discard/client.cc	/^  string message_;$/;"	m	class:DiscardClient	file:
+message_	examples/netty/echo/client.cc	/^  string message_;$/;"	m	class:EchoClient	file:
+message_	examples/pingpong/client.cc	/^  string message_;$/;"	m	class:Client	file:
+message_	examples/simple/chargen/chargen.h	/^  muduo::string message_;$/;"	m	class:ChargenServer
+message_	muduo/base/Exception.h	/^  string message_;$/;"	m	class:muduo::Exception
+messagesRead	examples/pingpong/client.cc	/^  int64_t messagesRead() const$/;"	f	class:Session
+messagesRead_	examples/pingpong/client.cc	/^  int64_t messagesRead_;$/;"	m	class:Session	file:
+method	muduo/net/http/HttpRequest.h	/^  Method method() const$/;"	f	class:muduo::net::HttpRequest
+methodString	muduo/net/http/HttpRequest.h	/^  const char* methodString() const$/;"	f	class:muduo::net::HttpRequest
+method_	muduo/net/http/HttpRequest.h	/^  Method method_;$/;"	m	class:muduo::net::HttpRequest
+microSecondsSinceEpoch	muduo/base/Timestamp.h	/^  int64_t microSecondsSinceEpoch() const { return microSecondsSinceEpoch_; }$/;"	f	class:muduo::Timestamp
+microSecondsSinceEpoch_	muduo/base/Timestamp.h	/^  int64_t microSecondsSinceEpoch_;$/;"	m	class:muduo::Timestamp
+modules_	muduo/net/inspect/Inspector.h	/^  std::map<string, CommandList> modules_;$/;"	m	class:muduo::net::Inspector
+month	muduo/base/Date.h	/^    int month;  \/\/ [1..12]$/;"	m	struct:muduo::Date::YearMonthDay
+month	muduo/base/Date.h	/^  int month() const$/;"	f	class:muduo::Date
+mps	examples/wordcount/slowsink.py	/^	mps = 1.0$/;"	v
+mps	examples/wordcount/slowsink.py	/^	mps = float(sys.argv[1])$/;"	v
+muduo	examples/cdns/Resolver.h	/^namespace muduo$/;"	n
+muduo	examples/curl/Curl.h	/^namespace muduo$/;"	n
+muduo	examples/memcached/server/Item.h	/^namespace muduo$/;"	n
+muduo	muduo/base/AsyncLogging.h	/^namespace muduo$/;"	n
+muduo	muduo/base/Atomic.h	/^namespace muduo$/;"	n
+muduo	muduo/base/BlockingQueue.h	/^namespace muduo$/;"	n
+muduo	muduo/base/BoundedBlockingQueue.h	/^namespace muduo$/;"	n
+muduo	muduo/base/Condition.h	/^namespace muduo$/;"	n
+muduo	muduo/base/CountDownLatch.h	/^namespace muduo$/;"	n
+muduo	muduo/base/CurrentThread.h	/^namespace muduo$/;"	n
+muduo	muduo/base/Date.cc	/^namespace muduo$/;"	n	file:
+muduo	muduo/base/Date.h	/^namespace muduo$/;"	n
+muduo	muduo/base/Exception.h	/^namespace muduo$/;"	n
+muduo	muduo/base/FileUtil.h	/^namespace muduo$/;"	n
+muduo	muduo/base/LogFile.h	/^namespace muduo$/;"	n
+muduo	muduo/base/LogStream.cc	/^namespace muduo$/;"	n	file:
+muduo	muduo/base/LogStream.h	/^namespace muduo$/;"	n
+muduo	muduo/base/Logging.cc	/^namespace muduo$/;"	n	file:
+muduo	muduo/base/Logging.h	/^namespace muduo$/;"	n
+muduo	muduo/base/Mutex.h	/^namespace muduo$/;"	n
+muduo	muduo/base/ProcessInfo.cc	/^namespace muduo$/;"	n	file:
+muduo	muduo/base/ProcessInfo.h	/^namespace muduo$/;"	n
+muduo	muduo/base/Singleton.h	/^namespace muduo$/;"	n
+muduo	muduo/base/StringPiece.h	/^namespace muduo {$/;"	n
+muduo	muduo/base/Thread.cc	/^namespace muduo$/;"	n	file:
+muduo	muduo/base/Thread.h	/^namespace muduo$/;"	n
+muduo	muduo/base/ThreadLocal.h	/^namespace muduo$/;"	n
+muduo	muduo/base/ThreadLocalSingleton.h	/^namespace muduo$/;"	n
+muduo	muduo/base/ThreadPool.h	/^namespace muduo$/;"	n
+muduo	muduo/base/TimeZone.cc	/^namespace muduo$/;"	n	file:
+muduo	muduo/base/TimeZone.h	/^namespace muduo$/;"	n
+muduo	muduo/base/Timestamp.h	/^namespace muduo$/;"	n
+muduo	muduo/base/Types.h	/^namespace muduo$/;"	n
+muduo	muduo/base/copyable.h	/^namespace muduo$/;"	n
+muduo	muduo/net/Acceptor.h	/^namespace muduo$/;"	n
+muduo	muduo/net/Buffer.h	/^namespace muduo$/;"	n
+muduo	muduo/net/Callbacks.h	/^namespace muduo$/;"	n
+muduo	muduo/net/Channel.h	/^namespace muduo$/;"	n
+muduo	muduo/net/Connector.h	/^namespace muduo$/;"	n
+muduo	muduo/net/Endian.h	/^namespace muduo$/;"	n
+muduo	muduo/net/EventLoop.h	/^namespace muduo$/;"	n
+muduo	muduo/net/EventLoopThread.h	/^namespace muduo$/;"	n
+muduo	muduo/net/EventLoopThreadPool.h	/^namespace muduo$/;"	n
+muduo	muduo/net/InetAddress.h	/^namespace muduo$/;"	n
+muduo	muduo/net/Poller.h	/^namespace muduo$/;"	n
+muduo	muduo/net/Socket.h	/^namespace muduo$/;"	n
+muduo	muduo/net/SocketsOps.h	/^namespace muduo$/;"	n
+muduo	muduo/net/TcpClient.cc	/^namespace muduo$/;"	n	file:
+muduo	muduo/net/TcpClient.h	/^namespace muduo$/;"	n
+muduo	muduo/net/TcpConnection.h	/^namespace muduo$/;"	n
+muduo	muduo/net/TcpServer.h	/^namespace muduo$/;"	n
+muduo	muduo/net/Timer.h	/^namespace muduo$/;"	n
+muduo	muduo/net/TimerId.h	/^namespace muduo$/;"	n
+muduo	muduo/net/TimerQueue.cc	/^namespace muduo$/;"	n	file:
+muduo	muduo/net/TimerQueue.h	/^namespace muduo$/;"	n
+muduo	muduo/net/boilerplate.h	/^namespace muduo$/;"	n
+muduo	muduo/net/http/HttpContext.h	/^namespace muduo$/;"	n
+muduo	muduo/net/http/HttpRequest.h	/^namespace muduo$/;"	n
+muduo	muduo/net/http/HttpResponse.h	/^namespace muduo$/;"	n
+muduo	muduo/net/http/HttpServer.cc	/^namespace muduo$/;"	n	file:
+muduo	muduo/net/http/HttpServer.h	/^namespace muduo$/;"	n
+muduo	muduo/net/http/tests/HttpRequest_unittest.cc	/^namespace muduo$/;"	n	file:
+muduo	muduo/net/inspect/Inspector.h	/^namespace muduo$/;"	n
+muduo	muduo/net/inspect/PerformanceInspector.h	/^namespace muduo$/;"	n
+muduo	muduo/net/inspect/ProcessInspector.h	/^namespace muduo$/;"	n
+muduo	muduo/net/poller/EPollPoller.h	/^namespace muduo$/;"	n
+muduo	muduo/net/poller/PollPoller.h	/^namespace muduo$/;"	n
+muduo	muduo/net/protorpc/RpcChannel.h	/^namespace muduo$/;"	n
+muduo	muduo/net/protorpc/RpcCodec.h	/^namespace muduo$/;"	n
+muduo	muduo/net/protorpc/RpcServer.h	/^namespace muduo$/;"	n
+multiplexerAddress	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/MultiplexerTest.java	/^    private final InetSocketAddress multiplexerAddress;$/;"	f	class:MultiplexerTest	file:
+mutex	examples/memcached/server/MemcacheServer.h	/^    mutable muduo::MutexLock mutex;$/;"	m	struct:MemcacheServer::MapWithLock
+mutex_	examples/asio/chat/client.cc	/^  MutexLock mutex_;$/;"	m	class:ChatClient	file:
+mutex_	examples/asio/chat/server_threaded.cc	/^  MutexLock mutex_;$/;"	m	class:ChatServer	file:
+mutex_	examples/asio/chat/server_threaded_efficient.cc	/^  MutexLock mutex_;$/;"	m	class:ChatServer	file:
+mutex_	examples/asio/chat/server_threaded_highperformance.cc	/^  MutexLock mutex_;$/;"	m	class:ChatServer	file:
+mutex_	examples/asio/tutorial/timer5/timer.cc	/^  muduo::MutexLock mutex_;$/;"	m	class:Printer	file:
+mutex_	examples/asio/tutorial/timer6/timer.cc	/^  muduo::MutexLock mutex_;$/;"	m	class:Printer	file:
+mutex_	examples/memcached/server/MemcacheServer.h	/^  mutable muduo::MutexLock mutex_;$/;"	m	class:MemcacheServer
+mutex_	examples/multiplexer/multiplexer.cc	/^  MutexLock mutex_;$/;"	m	class:MultiplexServer	file:
+mutex_	examples/wordcount/hasher.cc	/^  MutexLock mutex_;$/;"	m	class:SendThrottler	file:
+mutex_	muduo/base/AsyncLogging.h	/^  muduo::MutexLock mutex_;$/;"	m	class:muduo::AsyncLogging
+mutex_	muduo/base/BlockingQueue.h	/^  mutable MutexLock mutex_;$/;"	m	class:muduo::BlockingQueue
+mutex_	muduo/base/BoundedBlockingQueue.h	/^  mutable MutexLock          mutex_;$/;"	m	class:muduo::BoundedBlockingQueue
+mutex_	muduo/base/Condition.h	/^  MutexLock& mutex_;$/;"	m	class:muduo::Condition
+mutex_	muduo/base/CountDownLatch.h	/^  mutable MutexLock mutex_;$/;"	m	class:muduo::CountDownLatch
+mutex_	muduo/base/LogFile.h	/^  boost::scoped_ptr<MutexLock> mutex_;$/;"	m	class:muduo::LogFile
+mutex_	muduo/base/Mutex.h	/^  MutexLock& mutex_;$/;"	m	class:muduo::MutexLockGuard
+mutex_	muduo/base/Mutex.h	/^  pthread_mutex_t mutex_;$/;"	m	class:muduo::MutexLock
+mutex_	muduo/base/ThreadPool.h	/^  MutexLock mutex_;$/;"	m	class:muduo::ThreadPool
+mutex_	muduo/net/EventLoop.h	/^  MutexLock mutex_;$/;"	m	class:muduo::net::EventLoop
+mutex_	muduo/net/EventLoopThread.h	/^  MutexLock mutex_;$/;"	m	class:muduo::net::EventLoopThread
+mutex_	muduo/net/TcpClient.h	/^  mutable MutexLock mutex_;$/;"	m	class:muduo::net::TcpClient
+mutex_	muduo/net/inspect/Inspector.h	/^  MutexLock mutex_;$/;"	m	class:muduo::net::Inspector
+mutex_	muduo/net/protorpc/RpcChannel.h	/^  MutexLock mutex_;$/;"	m	class:muduo::net::RpcChannel
+mysleep	muduo/base/tests/Thread_test.cc	/^void mysleep(int seconds)$/;"	f
+name	examples/sudoku/sudoku.cc	/^    int name;$/;"	m	struct:Node	file:
+name	muduo/base/CurrentThread.h	/^  inline const char* name()$/;"	f	namespace:muduo::CurrentThread
+name	muduo/base/Thread.h	/^  const string& name() const { return name_; }$/;"	f	class:muduo::Thread
+name	muduo/base/tests/SingletonThreadLocal_test.cc	/^  const std::string& name() const { return name_; }$/;"	f	class:Test
+name	muduo/base/tests/Singleton_test.cc	/^  const muduo::string& name() const { return name_; }$/;"	f	class:Test
+name	muduo/base/tests/ThreadLocalSingleton_test.cc	/^  const std::string& name() const { return name_; }$/;"	f	class:Test
+name	muduo/base/tests/ThreadLocal_test.cc	/^  const std::string& name() const { return name_; }$/;"	f	class:Test
+name	muduo/net/TcpConnection.h	/^  const string& name() const { return name_; }$/;"	f	class:muduo::net::TcpConnection
+name	muduo/net/TcpServer.h	/^  const string& name() const { return name_; }$/;"	f	class:muduo::net::TcpServer
+name_	examples/memcached/client/bench.cc	/^  string name_;$/;"	m	class:Client	file:
+name_	examples/sudoku/client.cc	/^  string name_;$/;"	m	class:SudokuClient	file:
+name_	muduo/base/Thread.cc	/^  string name_;$/;"	m	struct:muduo::detail::ThreadData	file:
+name_	muduo/base/Thread.h	/^  string     name_;$/;"	m	class:muduo::Thread
+name_	muduo/base/ThreadPool.h	/^  string name_;$/;"	m	class:muduo::ThreadPool
+name_	muduo/base/tests/SingletonThreadLocal_test.cc	/^  std::string name_;$/;"	m	class:Test	file:
+name_	muduo/base/tests/Singleton_test.cc	/^  muduo::string name_;$/;"	m	class:Test	file:
+name_	muduo/base/tests/ThreadLocalSingleton_test.cc	/^  std::string name_;$/;"	m	class:Test	file:
+name_	muduo/base/tests/ThreadLocal_test.cc	/^  std::string name_;$/;"	m	class:Test	file:
+name_	muduo/net/TcpClient.h	/^  const string name_;$/;"	m	class:muduo::net::TcpClient
+name_	muduo/net/TcpConnection.h	/^  string name_;$/;"	m	class:muduo::net::TcpConnection
+name_	muduo/net/TcpServer.h	/^  const string name_;$/;"	m	class:muduo::net::TcpServer
+names	muduo/base/TimeZone.cc	/^  vector<string> names;$/;"	m	struct:TimeZone::Data	file:
+neededBytes	examples/memcached/server/Item.h	/^  size_t neededBytes() const$/;"	f	class:Item
+needle_	examples/memcached/server/Session.h	/^  ItemPtr needle_;$/;"	m	class:Session
+net	examples/cdns/Resolver.h	/^namespace net$/;"	n	namespace:muduo
+net	examples/curl/Curl.h	/^namespace net$/;"	n	namespace:muduo
+net	examples/memcached/server/Item.h	/^namespace net$/;"	n	namespace:muduo
+net	muduo/net/Acceptor.h	/^namespace net$/;"	n	namespace:muduo
+net	muduo/net/Buffer.h	/^namespace net$/;"	n	namespace:muduo
+net	muduo/net/Callbacks.h	/^namespace net$/;"	n	namespace:muduo
+net	muduo/net/Channel.h	/^namespace net$/;"	n	namespace:muduo
+net	muduo/net/Connector.h	/^namespace net$/;"	n	namespace:muduo
+net	muduo/net/Endian.h	/^namespace net$/;"	n	namespace:muduo
+net	muduo/net/EventLoop.h	/^namespace net$/;"	n	namespace:muduo
+net	muduo/net/EventLoopThread.h	/^namespace net$/;"	n	namespace:muduo
+net	muduo/net/EventLoopThreadPool.h	/^namespace net$/;"	n	namespace:muduo
+net	muduo/net/InetAddress.h	/^namespace net$/;"	n	namespace:muduo
+net	muduo/net/Poller.h	/^namespace net$/;"	n	namespace:muduo
+net	muduo/net/Socket.h	/^namespace net$/;"	n	namespace:muduo
+net	muduo/net/SocketsOps.h	/^namespace net$/;"	n	namespace:muduo
+net	muduo/net/TcpClient.cc	/^namespace net$/;"	n	namespace:muduo	file:
+net	muduo/net/TcpClient.h	/^namespace net$/;"	n	namespace:muduo
+net	muduo/net/TcpConnection.h	/^namespace net$/;"	n	namespace:muduo
+net	muduo/net/TcpServer.h	/^namespace net$/;"	n	namespace:muduo
+net	muduo/net/Timer.h	/^namespace net$/;"	n	namespace:muduo
+net	muduo/net/TimerId.h	/^namespace net$/;"	n	namespace:muduo
+net	muduo/net/TimerQueue.cc	/^namespace net$/;"	n	namespace:muduo	file:
+net	muduo/net/TimerQueue.h	/^namespace net$/;"	n	namespace:muduo
+net	muduo/net/boilerplate.h	/^namespace net$/;"	n	namespace:muduo
+net	muduo/net/http/HttpContext.h	/^namespace net$/;"	n	namespace:muduo
+net	muduo/net/http/HttpRequest.h	/^namespace net$/;"	n	namespace:muduo
+net	muduo/net/http/HttpResponse.h	/^namespace net$/;"	n	namespace:muduo
+net	muduo/net/http/HttpServer.cc	/^namespace net$/;"	n	namespace:muduo	file:
+net	muduo/net/http/HttpServer.h	/^namespace net$/;"	n	namespace:muduo
+net	muduo/net/http/tests/HttpRequest_unittest.cc	/^namespace net$/;"	n	namespace:muduo	file:
+net	muduo/net/inspect/Inspector.h	/^namespace net$/;"	n	namespace:muduo
+net	muduo/net/inspect/PerformanceInspector.h	/^namespace net$/;"	n	namespace:muduo
+net	muduo/net/inspect/ProcessInspector.h	/^namespace net$/;"	n	namespace:muduo
+net	muduo/net/poller/EPollPoller.h	/^namespace net$/;"	n	namespace:muduo
+net	muduo/net/poller/PollPoller.h	/^namespace net$/;"	n	namespace:muduo
+net	muduo/net/protorpc/RpcChannel.h	/^namespace net$/;"	n	namespace:muduo
+net	muduo/net/protorpc/RpcCodec.h	/^namespace net$/;"	n	namespace:muduo
+net	muduo/net/protorpc/RpcServer.h	/^namespace net$/;"	n	namespace:muduo
+networkToHost16	muduo/net/Endian.h	/^inline uint16_t networkToHost16(uint16_t net16)$/;"	f	namespace:muduo::net::sockets
+networkToHost32	muduo/net/Endian.h	/^inline uint32_t networkToHost32(uint32_t net32)$/;"	f	namespace:muduo::net::sockets
+networkToHost64	muduo/net/Endian.h	/^inline uint64_t networkToHost64(uint64_t net64)$/;"	f	namespace:muduo::net::sockets
+newClient	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/MultiplexerTest.java	/^    public MockClient newClient() {$/;"	m	class:MultiplexerTest
+newConnection	muduo/net/TcpClient.cc	/^void TcpClient::newConnection(int sockfd)$/;"	f	class:TcpClient
+newConnection	muduo/net/TcpServer.cc	/^void TcpServer::newConnection(int sockfd, const InetAddress& peerAddr)$/;"	f	class:TcpServer
+newConnectionCallback_	muduo/net/Acceptor.h	/^  NewConnectionCallback newConnectionCallback_;$/;"	m	class:muduo::net::Acceptor
+newConnectionCallback_	muduo/net/Connector.h	/^  NewConnectionCallback newConnectionCallback_;$/;"	m	class:muduo::net::Connector
+newDefaultPoller	muduo/net/poller/DefaultPoller.cc	/^Poller* Poller::newDefaultPoller(EventLoop* loop)$/;"	f	class:Poller
+new_column	examples/sudoku/sudoku.cc	/^    Column* new_column(int n = 0)$/;"	f	class:SudokuSolver	file:
+new_row	examples/sudoku/sudoku.cc	/^    Node* new_row(int col)$/;"	f	class:SudokuSolver	file:
+nextBuffer_	muduo/base/AsyncLogging.h	/^  BufferPtr nextBuffer_;$/;"	m	class:muduo::AsyncLogging
+nextConnId_	muduo/net/TcpClient.h	/^  int nextConnId_;$/;"	m	class:muduo::net::TcpClient
+nextConnId_	muduo/net/TcpServer.h	/^  int nextConnId_;$/;"	m	class:muduo::net::TcpServer
+next_	muduo/net/EventLoopThreadPool.h	/^  int next_;$/;"	m	class:muduo::net::EventLoopThreadPool
+nodes_	examples/sudoku/sudoku.cc	/^    Node    nodes_[kMaxNodes];$/;"	m	class:SudokuSolver	file:
+noreply_	examples/memcached/server/Session.h	/^  bool noreply_;$/;"	m	class:Session
+notEmpty_	muduo/base/BlockingQueue.h	/^  Condition         notEmpty_;$/;"	m	class:muduo::BlockingQueue
+notEmpty_	muduo/base/BoundedBlockingQueue.h	/^  Condition                  notEmpty_;$/;"	m	class:muduo::BoundedBlockingQueue
+notEmpty_	muduo/base/ThreadPool.h	/^  Condition notEmpty_;$/;"	m	class:muduo::ThreadPool
+notFull_	muduo/base/BoundedBlockingQueue.h	/^  Condition                  notFull_;$/;"	m	class:muduo::BoundedBlockingQueue
+notFull_	muduo/base/ThreadPool.h	/^  Condition notFull_;$/;"	m	class:muduo::ThreadPool
+notify	muduo/base/Condition.h	/^  void notify()$/;"	f	class:muduo::Condition
+notifyAll	muduo/base/Condition.h	/^  void notifyAll()$/;"	f	class:muduo::Condition
+now	muduo/base/Timestamp.cc	/^Timestamp Timestamp::now()$/;"	f	class:Timestamp
+numActive	examples/pingpong/bench.cc	/^int numActive;$/;"	v
+numConnected_	examples/maxconnection/echo.h	/^  int numConnected_; \/\/ should be atomic_int$/;"	m	class:EchoServer
+numConnected_	examples/pingpong/client.cc	/^  AtomicInt32 numConnected_;$/;"	m	class:Client	file:
+numCreated	muduo/base/Thread.h	/^  static int numCreated() { return numCreated_.get(); }$/;"	f	class:muduo::Thread
+numCreated	muduo/net/Timer.h	/^  static int64_t numCreated() { return s_numCreated_.get(); }$/;"	f	class:muduo::net::Timer
+numCreated_	muduo/base/Thread.cc	/^AtomicInt32 Thread::numCreated_;$/;"	m	class:Thread	file:
+numCreated_	muduo/base/Thread.h	/^  static AtomicInt32 numCreated_;$/;"	m	class:muduo::Thread
+numPipes	examples/pingpong/bench.cc	/^int numPipes;$/;"	v
+numThreads	examples/netty/discard/server.cc	/^int numThreads = 0;$/;"	v
+numThreads	examples/netty/echo/server.cc	/^int numThreads = 0;$/;"	v
+numThreads	muduo/base/ProcessInfo.cc	/^int ProcessInfo::numThreads()$/;"	f	class:ProcessInfo
+numThreads	muduo/net/tests/EchoClient_unittest.cc	/^int numThreads = 0;$/;"	v
+numThreads	muduo/net/tests/EchoServer_unittest.cc	/^int numThreads = 0;$/;"	v
+numThreads_	examples/multiplexer/multiplexer.cc	/^  int numThreads_;$/;"	m	class:MultiplexServer	file:
+numThreads_	examples/sudoku/server_multiloop.cc	/^  int numThreads_;$/;"	m	class:SudokuServer	file:
+numThreads_	examples/sudoku/server_threadpool.cc	/^  int numThreads_;$/;"	m	class:SudokuServer	file:
+numThreads_	muduo/net/EventLoopThreadPool.h	/^  int numThreads_;$/;"	m	class:muduo::net::EventLoopThreadPool
+numWrites	examples/pingpong/bench.cc	/^int numWrites;$/;"	v
+oldCounter_	examples/multiplexer/multiplexer.cc	/^  int64_t oldCounter_;$/;"	m	class:MultiplexServer	file:
+oldCounter_	examples/netty/discard/server.cc	/^  int64_t oldCounter_;$/;"	m	class:DiscardServer	file:
+oldCounter_	examples/netty/echo/server.cc	/^  int64_t oldCounter_;$/;"	m	class:EchoServer	file:
+onAnswer	examples/protobuf/codec/client.cc	/^  void onAnswer(const muduo::net::TcpConnectionPtr&,$/;"	f	class:QueryClient	file:
+onAnswer	examples/protobuf/codec/dispatcher_lite_test.cc	/^void onAnswer(const muduo::net::TcpConnectionPtr&,$/;"	f
+onAnswer	examples/protobuf/codec/dispatcher_test.cc	/^void onAnswer(const muduo::net::TcpConnectionPtr&,$/;"	f
+onAnswer	examples/protobuf/codec/server.cc	/^  void onAnswer(const muduo::net::TcpConnectionPtr& conn,$/;"	f	class:QueryServer	file:
+onBackendConnection	examples/multiplexer/multiplexer.cc	/^  void onBackendConnection(const TcpConnectionPtr& conn)$/;"	f	class:MultiplexServer	file:
+onBackendConnection	examples/multiplexer/multiplexer_simple.cc	/^  void onBackendConnection(const TcpConnectionPtr& conn)$/;"	f	class:MultiplexServer	file:
+onBackendMessage	examples/multiplexer/multiplexer.cc	/^  void onBackendMessage(const TcpConnectionPtr& conn, Buffer* buf, Timestamp)$/;"	f	class:MultiplexServer	file:
+onBackendMessage	examples/multiplexer/multiplexer_simple.cc	/^  void onBackendMessage(const TcpConnectionPtr& conn, Buffer* buf, Timestamp)$/;"	f	class:MultiplexServer	file:
+onBeginRequest	examples/fastcgi/fastcgi.cc	/^bool FastCgiCodec::onBeginRequest(const RecordHeader& header, const Buffer* buf)$/;"	f	class:FastCgiCodec
+onClientConnection	examples/multiplexer/multiplexer.cc	/^  void onClientConnection(const TcpConnectionPtr& conn)$/;"	f	class:MultiplexServer	file:
+onClientConnection	examples/multiplexer/multiplexer_simple.cc	/^  void onClientConnection(const TcpConnectionPtr& conn)$/;"	f	class:MultiplexServer	file:
+onClientConnection	examples/socks4a/tunnel.h	/^  void onClientConnection(const muduo::net::TcpConnectionPtr& conn)$/;"	f	class:Tunnel
+onClientMessage	examples/multiplexer/multiplexer.cc	/^  void onClientMessage(const TcpConnectionPtr& conn, Buffer* buf, Timestamp)$/;"	f	class:MultiplexServer	file:
+onClientMessage	examples/multiplexer/multiplexer_simple.cc	/^  void onClientMessage(const TcpConnectionPtr& conn, Buffer* buf, Timestamp)$/;"	f	class:MultiplexServer	file:
+onClientMessage	examples/socks4a/tunnel.h	/^  void onClientMessage(const muduo::net::TcpConnectionPtr& conn,$/;"	f	class:Tunnel
+onConnect	examples/pingpong/client.cc	/^  void onConnect()$/;"	f	class:Client
+onConnection	examples/asio/chat/client.cc	/^  void onConnection(const TcpConnectionPtr& conn)$/;"	f	class:ChatClient	file:
+onConnection	examples/asio/chat/loadtest.cc	/^  void onConnection(const TcpConnectionPtr& conn)$/;"	f	class:ChatClient	file:
+onConnection	examples/asio/chat/server.cc	/^  void onConnection(const TcpConnectionPtr& conn)$/;"	f	class:ChatServer	file:
+onConnection	examples/asio/chat/server_threaded.cc	/^  void onConnection(const TcpConnectionPtr& conn)$/;"	f	class:ChatServer	file:
+onConnection	examples/asio/chat/server_threaded_efficient.cc	/^  void onConnection(const TcpConnectionPtr& conn)$/;"	f	class:ChatServer	file:
+onConnection	examples/asio/chat/server_threaded_highperformance.cc	/^  void onConnection(const TcpConnectionPtr& conn)$/;"	f	class:ChatServer	file:
+onConnection	examples/fastcgi/fastcgi_test.cc	/^void onConnection(const TcpConnectionPtr& conn)$/;"	f
+onConnection	examples/filetransfer/download.cc	/^void onConnection(const TcpConnectionPtr& conn)$/;"	f
+onConnection	examples/filetransfer/download2.cc	/^void onConnection(const TcpConnectionPtr& conn)$/;"	f
+onConnection	examples/filetransfer/download3.cc	/^void onConnection(const TcpConnectionPtr& conn)$/;"	f
+onConnection	examples/hub/hub.cc	/^  void onConnection(const TcpConnectionPtr& conn)$/;"	f	class:pubsub::PubSubServer	file:
+onConnection	examples/hub/pubsub.cc	/^void PubSubClient::onConnection(const TcpConnectionPtr& conn)$/;"	f	class:PubSubClient
+onConnection	examples/idleconnection/echo.cc	/^void EchoServer::onConnection(const TcpConnectionPtr& conn)$/;"	f	class:EchoServer
+onConnection	examples/idleconnection/sortedlist.cc	/^void EchoServer::onConnection(const TcpConnectionPtr& conn)$/;"	f	class:EchoServer
+onConnection	examples/maxconnection/echo.cc	/^void EchoServer::onConnection(const TcpConnectionPtr& conn)$/;"	f	class:EchoServer
+onConnection	examples/memcached/client/bench.cc	/^  void onConnection(const TcpConnectionPtr& conn)$/;"	f	class:Client	file:
+onConnection	examples/memcached/server/MemcacheServer.cc	/^void MemcacheServer::onConnection(const TcpConnectionPtr& conn)$/;"	f	class:MemcacheServer
+onConnection	examples/netty/discard/client.cc	/^  void onConnection(const TcpConnectionPtr& conn)$/;"	f	class:DiscardClient	file:
+onConnection	examples/netty/discard/server.cc	/^  void onConnection(const TcpConnectionPtr& conn)$/;"	f	class:DiscardServer	file:
+onConnection	examples/netty/echo/client.cc	/^  void onConnection(const TcpConnectionPtr& conn)$/;"	f	class:EchoClient	file:
+onConnection	examples/netty/echo/server.cc	/^  void onConnection(const TcpConnectionPtr& conn)$/;"	f	class:EchoServer	file:
+onConnection	examples/netty/uptime/uptime.cc	/^  void onConnection(const TcpConnectionPtr& conn)$/;"	f	class:UptimeClient	file:
+onConnection	examples/pingpong/client.cc	/^void Session::onConnection(const TcpConnectionPtr& conn)$/;"	f	class:Session
+onConnection	examples/pingpong/server.cc	/^void onConnection(const TcpConnectionPtr& conn)$/;"	f
+onConnection	examples/protobuf/codec/client.cc	/^  void onConnection(const TcpConnectionPtr& conn)$/;"	f	class:QueryClient	file:
+onConnection	examples/protobuf/codec/server.cc	/^  void onConnection(const TcpConnectionPtr& conn)$/;"	f	class:QueryServer	file:
+onConnection	examples/protobuf/resolver/client.cc	/^  void onConnection(const TcpConnectionPtr& conn)$/;"	f	class:RpcClient	file:
+onConnection	examples/protobuf/rpc/client.cc	/^  void onConnection(const TcpConnectionPtr& conn)$/;"	f	class:RpcClient	file:
+onConnection	examples/protobuf/rpcbench/client.cc	/^  void onConnection(const TcpConnectionPtr& conn)$/;"	f	class:RpcClient	file:
+onConnection	examples/simple/chargen/chargen.cc	/^void ChargenServer::onConnection(const TcpConnectionPtr& conn)$/;"	f	class:ChargenServer
+onConnection	examples/simple/chargenclient/chargenclient.cc	/^  void onConnection(const TcpConnectionPtr& conn)$/;"	f	class:ChargenClient	file:
+onConnection	examples/simple/daytime/daytime.cc	/^void DaytimeServer::onConnection(const TcpConnectionPtr& conn)$/;"	f	class:DaytimeServer
+onConnection	examples/simple/discard/discard.cc	/^void DiscardServer::onConnection(const TcpConnectionPtr& conn)$/;"	f	class:DiscardServer
+onConnection	examples/simple/echo/echo.cc	/^void EchoServer::onConnection(const muduo::net::TcpConnectionPtr& conn)$/;"	f	class:EchoServer
+onConnection	examples/simple/time/time.cc	/^void TimeServer::onConnection(const muduo::net::TcpConnectionPtr& conn)$/;"	f	class:TimeServer
+onConnection	examples/simple/timeclient/timeclient.cc	/^  void onConnection(const TcpConnectionPtr& conn)$/;"	f	class:TimeClient	file:
+onConnection	examples/sudoku/client.cc	/^  void onConnection(const TcpConnectionPtr& conn)$/;"	f	class:SudokuClient	file:
+onConnection	examples/sudoku/server_basic.cc	/^  void onConnection(const TcpConnectionPtr& conn)$/;"	f	class:SudokuServer	file:
+onConnection	examples/sudoku/server_multiloop.cc	/^  void onConnection(const TcpConnectionPtr& conn)$/;"	f	class:SudokuServer	file:
+onConnection	examples/sudoku/server_threadpool.cc	/^  void onConnection(const TcpConnectionPtr& conn)$/;"	f	class:SudokuServer	file:
+onConnection	examples/twisted/finger/finger03.cc	/^void onConnection(const TcpConnectionPtr& conn)$/;"	f
+onConnection	examples/wordcount/hasher.cc	/^  void onConnection(const TcpConnectionPtr& conn)$/;"	f	class:SendThrottler	file:
+onConnection	examples/wordcount/receiver.cc	/^  void onConnection(const TcpConnectionPtr& conn)$/;"	f	class:WordCountReceiver	file:
+onConnection	examples/zeromq/local_lat.cc	/^void onConnection(const muduo::net::TcpConnectionPtr& conn)$/;"	f
+onConnection	examples/zeromq/remote_lat.cc	/^void onConnection(LengthHeaderCodec* codec, const muduo::net::TcpConnectionPtr& conn)$/;"	f
+onConnection	muduo/net/http/HttpServer.cc	/^void HttpServer::onConnection(const TcpConnectionPtr& conn)$/;"	f	class:HttpServer
+onConnection	muduo/net/protorpc/RpcServer.cc	/^void RpcServer::onConnection(const TcpConnectionPtr& conn)$/;"	f	class:RpcServer
+onConnection	muduo/net/tests/EchoClient_unittest.cc	/^  void onConnection(const TcpConnectionPtr& conn)$/;"	f	class:EchoClient	file:
+onConnection	muduo/net/tests/EchoServer_unittest.cc	/^  void onConnection(const TcpConnectionPtr& conn)$/;"	f	class:EchoServer	file:
+onData	examples/curl/download.cc	/^  void onData(const char* data, int len)$/;"	f	class:Downloader	file:
+onData	examples/curl/download.cc	/^  void onData(const char* data, int len)$/;"	f	class:Piece	file:
+onData	examples/curl/mcurl.cc	/^void onData(const char* data, int len)$/;"	f
+onDisconnect	examples/pingpong/client.cc	/^  void onDisconnect(const TcpConnectionPtr& conn)$/;"	f	class:Client
+onDone	examples/curl/download.cc	/^  void onDone(curl::Request* c, int code)$/;"	f	class:Piece	file:
+onDownloadDone	examples/curl/download.cc	/^  void onDownloadDone()$/;"	f	class:Downloader	file:
+onEmpty	examples/protobuf/codec/client.cc	/^  void onEmpty(const muduo::net::TcpConnectionPtr&,$/;"	f	class:QueryClient	file:
+onHeader	examples/curl/download.cc	/^  void onHeader(const char* data, int len)$/;"	f	class:Downloader	file:
+onHeaderDone	examples/curl/download.cc	/^  void onHeaderDone(curl::Request* c, int code)$/;"	f	class:Downloader	file:
+onHighWaterMark	examples/filetransfer/download.cc	/^void onHighWaterMark(const TcpConnectionPtr& conn, size_t len)$/;"	f
+onHighWaterMark	examples/filetransfer/download2.cc	/^void onHighWaterMark(const TcpConnectionPtr& conn, size_t len)$/;"	f
+onHighWaterMark	examples/filetransfer/download3.cc	/^void onHighWaterMark(const TcpConnectionPtr& conn, size_t len)$/;"	f
+onHighWaterMark	examples/socks4a/tunnel.h	/^  void onHighWaterMark(const muduo::net::TcpConnectionPtr& conn,$/;"	f	class:Tunnel
+onHighWaterMark	examples/wordcount/hasher.cc	/^  void onHighWaterMark()$/;"	f	class:SendThrottler	file:
+onHighWaterMarkWeak	examples/socks4a/tunnel.h	/^  static void onHighWaterMarkWeak(const boost::weak_ptr<Tunnel>& wkTunnel,$/;"	f	class:Tunnel
+onMessage	examples/asio/chat/codec.h	/^  void onMessage(const muduo::net::TcpConnectionPtr& conn,$/;"	f	class:LengthHeaderCodec
+onMessage	examples/fastcgi/fastcgi.h	/^  void onMessage(const muduo::net::TcpConnectionPtr& conn,$/;"	f	class:FastCgiCodec
+onMessage	examples/hub/hub.cc	/^  void onMessage(const TcpConnectionPtr& conn,$/;"	f	class:pubsub::PubSubServer	file:
+onMessage	examples/hub/pubsub.cc	/^void PubSubClient::onMessage(const TcpConnectionPtr& conn,$/;"	f	class:PubSubClient
+onMessage	examples/idleconnection/echo.cc	/^void EchoServer::onMessage(const TcpConnectionPtr& conn,$/;"	f	class:EchoServer
+onMessage	examples/idleconnection/sortedlist.cc	/^void EchoServer::onMessage(const TcpConnectionPtr& conn,$/;"	f	class:EchoServer
+onMessage	examples/maxconnection/echo.cc	/^void EchoServer::onMessage(const TcpConnectionPtr& conn,$/;"	f	class:EchoServer
+onMessage	examples/memcached/client/bench.cc	/^  void onMessage(const TcpConnectionPtr& conn,$/;"	f	class:Client	file:
+onMessage	examples/memcached/server/Session.cc	/^void Session::onMessage(const muduo::net::TcpConnectionPtr& conn,$/;"	f	class:Session
+onMessage	examples/netty/discard/client.cc	/^  void onMessage(const TcpConnectionPtr& conn, Buffer* buf, Timestamp time)$/;"	f	class:DiscardClient	file:
+onMessage	examples/netty/discard/server.cc	/^  void onMessage(const TcpConnectionPtr& conn, Buffer* buf, Timestamp)$/;"	f	class:DiscardServer	file:
+onMessage	examples/netty/echo/client.cc	/^  void onMessage(const TcpConnectionPtr& conn, Buffer* buf, Timestamp time)$/;"	f	class:EchoClient	file:
+onMessage	examples/netty/echo/server.cc	/^  void onMessage(const TcpConnectionPtr& conn, Buffer* buf, Timestamp)$/;"	f	class:EchoServer	file:
+onMessage	examples/netty/uptime/uptime.cc	/^  void onMessage(const TcpConnectionPtr& conn, Buffer* buf, Timestamp time)$/;"	f	class:UptimeClient	file:
+onMessage	examples/pingpong/client.cc	/^  void onMessage(const TcpConnectionPtr& conn, Buffer* buf, Timestamp)$/;"	f	class:Session	file:
+onMessage	examples/pingpong/server.cc	/^void onMessage(const TcpConnectionPtr& conn, Buffer* buf, Timestamp)$/;"	f
+onMessage	examples/protobuf/codec/codec.cc	/^void ProtobufCodec::onMessage(const TcpConnectionPtr& conn,$/;"	f	class:ProtobufCodec
+onMessage	examples/protobuf/codec/codec_test.cc	/^void onMessage(const muduo::net::TcpConnectionPtr& conn,$/;"	f
+onMessage	examples/protobuf/codec/dispatcher.h	/^  virtual void onMessage(const muduo::net::TcpConnectionPtr& conn,$/;"	f	class:CallbackT
+onMessage	examples/simple/chargen/chargen.cc	/^void ChargenServer::onMessage(const TcpConnectionPtr& conn,$/;"	f	class:ChargenServer
+onMessage	examples/simple/chargenclient/chargenclient.cc	/^  void onMessage(const TcpConnectionPtr& conn, Buffer* buf, Timestamp receiveTime)$/;"	f	class:ChargenClient	file:
+onMessage	examples/simple/daytime/daytime.cc	/^void DaytimeServer::onMessage(const TcpConnectionPtr& conn,$/;"	f	class:DaytimeServer
+onMessage	examples/simple/discard/discard.cc	/^void DiscardServer::onMessage(const TcpConnectionPtr& conn,$/;"	f	class:DiscardServer
+onMessage	examples/simple/echo/echo.cc	/^void EchoServer::onMessage(const muduo::net::TcpConnectionPtr& conn,$/;"	f	class:EchoServer
+onMessage	examples/simple/time/time.cc	/^void TimeServer::onMessage(const muduo::net::TcpConnectionPtr& conn,$/;"	f	class:TimeServer
+onMessage	examples/simple/timeclient/timeclient.cc	/^  void onMessage(const TcpConnectionPtr& conn, Buffer* buf, Timestamp receiveTime)$/;"	f	class:TimeClient	file:
+onMessage	examples/sudoku/client.cc	/^  void onMessage(const TcpConnectionPtr& conn, Buffer* buf, Timestamp)$/;"	f	class:SudokuClient	file:
+onMessage	examples/sudoku/server_basic.cc	/^  void onMessage(const TcpConnectionPtr& conn, Buffer* buf, Timestamp)$/;"	f	class:SudokuServer	file:
+onMessage	examples/sudoku/server_multiloop.cc	/^  void onMessage(const TcpConnectionPtr& conn, Buffer* buf, Timestamp)$/;"	f	class:SudokuServer	file:
+onMessage	examples/sudoku/server_threadpool.cc	/^  void onMessage(const TcpConnectionPtr& conn, Buffer* buf, Timestamp)$/;"	f	class:SudokuServer	file:
+onMessage	examples/twisted/finger/finger04.cc	/^void onMessage(const TcpConnectionPtr& conn,$/;"	f
+onMessage	examples/twisted/finger/finger05.cc	/^void onMessage(const TcpConnectionPtr& conn,$/;"	f
+onMessage	examples/twisted/finger/finger06.cc	/^void onMessage(const TcpConnectionPtr& conn,$/;"	f
+onMessage	examples/twisted/finger/finger07.cc	/^void onMessage(const TcpConnectionPtr& conn,$/;"	f
+onMessage	examples/wordcount/receiver.cc	/^  void onMessage(const TcpConnectionPtr& conn, Buffer* buf, Timestamp)$/;"	f	class:WordCountReceiver	file:
+onMessage	muduo/net/http/HttpServer.cc	/^void HttpServer::onMessage(const TcpConnectionPtr& conn,$/;"	f	class:HttpServer
+onMessage	muduo/net/protorpc/RpcChannel.cc	/^void RpcChannel::onMessage(const TcpConnectionPtr& conn,$/;"	f	class:RpcChannel
+onMessage	muduo/net/protorpc/RpcCodec.cc	/^void RpcCodec::onMessage(const TcpConnectionPtr& conn,$/;"	f	class:RpcCodec
+onMessage	muduo/net/tests/EchoClient_unittest.cc	/^  void onMessage(const TcpConnectionPtr& conn, Buffer* buf, Timestamp time)$/;"	f	class:EchoClient	file:
+onMessage	muduo/net/tests/EchoServer_unittest.cc	/^  void onMessage(const TcpConnectionPtr& conn, Buffer* buf, Timestamp time)$/;"	f	class:EchoServer	file:
+onParams	examples/fastcgi/fastcgi.cc	/^bool FastCgiCodec::onParams(const char* content, uint16_t length)$/;"	f	class:FastCgiCodec
+onProtobufMessage	examples/protobuf/codec/dispatcher.h	/^  void onProtobufMessage(const muduo::net::TcpConnectionPtr& conn,$/;"	f	class:ProtobufDispatcher
+onProtobufMessage	examples/protobuf/codec/dispatcher_lite.h	/^  void onProtobufMessage(const muduo::net::TcpConnectionPtr& conn,$/;"	f	class:ProtobufDispatcherLite
+onQuery	examples/protobuf/codec/dispatcher_lite_test.cc	/^void onQuery(const muduo::net::TcpConnectionPtr&,$/;"	f
+onQuery	examples/protobuf/codec/dispatcher_test.cc	/^void onQuery(const muduo::net::TcpConnectionPtr&,$/;"	f
+onQuery	examples/protobuf/codec/server.cc	/^  void onQuery(const muduo::net::TcpConnectionPtr& conn,$/;"	f	class:QueryServer	file:
+onQueryResult	examples/cdns/Resolver.cc	/^void Resolver::onQueryResult(int status, struct hostent* result, const Callback& callback)$/;"	f	class:Resolver
+onRead	examples/cdns/Resolver.cc	/^void Resolver::onRead(int sockfd, Timestamp t)$/;"	f	class:Resolver
+onRead	examples/curl/Curl.cc	/^void Curl::onRead(int fd)$/;"	f	class:Curl
+onRequest	examples/fastcgi/fastcgi_test.cc	/^void onRequest(const TcpConnectionPtr& conn,$/;"	f
+onRequest	examples/shorturl/shorturl.cc	/^void onRequest(const HttpRequest& req, HttpResponse* resp)$/;"	f
+onRequest	muduo/net/http/HttpServer.cc	/^void HttpServer::onRequest(const TcpConnectionPtr& conn, const HttpRequest& req)$/;"	f	class:HttpServer
+onRequest	muduo/net/http/tests/HttpServer_test.cc	/^void onRequest(const HttpRequest& req, HttpResponse* resp)$/;"	f
+onRequest	muduo/net/inspect/Inspector.cc	/^void Inspector::onRequest(const HttpRequest& req, HttpResponse* resp)$/;"	f	class:Inspector
+onRpcMessage	muduo/net/protorpc/RpcChannel.cc	/^void RpcChannel::onRpcMessage(const TcpConnectionPtr& conn,$/;"	f	class:RpcChannel
+onServerConnection	examples/multiplexer/demux.cc	/^  void onServerConnection(const TcpConnectionPtr& conn)$/;"	f	class:DemuxServer
+onServerConnection	examples/socks4a/socks4a.cc	/^void onServerConnection(const TcpConnectionPtr& conn)$/;"	f
+onServerConnection	examples/socks4a/tcprelay.cc	/^void onServerConnection(const TcpConnectionPtr& conn)$/;"	f
+onServerMessage	examples/multiplexer/demux.cc	/^  void onServerMessage(const TcpConnectionPtr& conn, Buffer* buf, Timestamp)$/;"	f	class:DemuxServer
+onServerMessage	examples/socks4a/socks4a.cc	/^void onServerMessage(const TcpConnectionPtr& conn, Buffer* buf, Timestamp)$/;"	f
+onServerMessage	examples/socks4a/tcprelay.cc	/^void onServerMessage(const TcpConnectionPtr& conn, Buffer* buf, Timestamp)$/;"	f
+onSockCreate	examples/cdns/Resolver.cc	/^void Resolver::onSockCreate(int sockfd, int type)$/;"	f	class:Resolver
+onSockStateChange	examples/cdns/Resolver.cc	/^void Resolver::onSockStateChange(int sockfd, bool read, bool write)$/;"	f	class:Resolver
+onSocksConnection	examples/multiplexer/demux.cc	/^  void onSocksConnection(int connId, const TcpConnectionPtr& conn)$/;"	f	class:DemuxServer
+onSocksMessage	examples/multiplexer/demux.cc	/^  void onSocksMessage(int connId, const TcpConnectionPtr& conn, Buffer* buf, Timestamp)$/;"	f	class:DemuxServer
+onStdin	examples/fastcgi/fastcgi.cc	/^void FastCgiCodec::onStdin(const char* content, uint16_t length)$/;"	f	class:FastCgiCodec
+onStringMessage	examples/asio/chat/client.cc	/^  void onStringMessage(const TcpConnectionPtr&,$/;"	f	class:ChatClient	file:
+onStringMessage	examples/asio/chat/loadtest.cc	/^  void onStringMessage(const TcpConnectionPtr&,$/;"	f	class:ChatClient	file:
+onStringMessage	examples/asio/chat/server.cc	/^  void onStringMessage(const TcpConnectionPtr&,$/;"	f	class:ChatServer	file:
+onStringMessage	examples/asio/chat/server_threaded.cc	/^  void onStringMessage(const TcpConnectionPtr&,$/;"	f	class:ChatServer	file:
+onStringMessage	examples/asio/chat/server_threaded_efficient.cc	/^  void onStringMessage(const TcpConnectionPtr&,$/;"	f	class:ChatServer	file:
+onStringMessage	examples/asio/chat/server_threaded_highperformance.cc	/^  void onStringMessage(const TcpConnectionPtr&,$/;"	f	class:ChatServer	file:
+onStringMessage	examples/zeromq/local_lat.cc	/^void onStringMessage(LengthHeaderCodec* codec,$/;"	f
+onStringMessage	examples/zeromq/remote_lat.cc	/^void onStringMessage(LengthHeaderCodec* codec,$/;"	f
+onTimer	examples/cdns/Resolver.cc	/^void Resolver::onTimer()$/;"	f	class:Resolver
+onTimer	examples/curl/Curl.cc	/^void Curl::onTimer()$/;"	f	class:Curl
+onTimer	examples/idleconnection/echo.cc	/^void EchoServer::onTimer()$/;"	f	class:EchoServer
+onTimer	examples/idleconnection/sortedlist.cc	/^void EchoServer::onTimer()$/;"	f	class:EchoServer
+onUnknownMessage	examples/protobuf/codec/client.cc	/^  void onUnknownMessage(const TcpConnectionPtr&,$/;"	f	class:QueryClient	file:
+onUnknownMessage	examples/protobuf/codec/server.cc	/^  void onUnknownMessage(const TcpConnectionPtr& conn,$/;"	f	class:QueryServer	file:
+onUnknownMessageType	examples/protobuf/codec/dispatcher_lite_test.cc	/^void onUnknownMessageType(const muduo::net::TcpConnectionPtr&,$/;"	f
+onUnknownMessageType	examples/protobuf/codec/dispatcher_test.cc	/^void onUnknownMessageType(const muduo::net::TcpConnectionPtr&,$/;"	f
+onWrite	examples/curl/Curl.cc	/^void Curl::onWrite(int fd)$/;"	f	class:Curl
+onWriteComplete	examples/filetransfer/download2.cc	/^void onWriteComplete(const TcpConnectionPtr& conn)$/;"	f
+onWriteComplete	examples/filetransfer/download3.cc	/^void onWriteComplete(const TcpConnectionPtr& conn)$/;"	f
+onWriteComplete	examples/netty/discard/client.cc	/^  void onWriteComplete(const TcpConnectionPtr& conn)$/;"	f	class:DiscardClient	file:
+onWriteComplete	examples/simple/chargen/chargen.cc	/^void ChargenServer::onWriteComplete(const TcpConnectionPtr& conn)$/;"	f	class:ChargenServer
+onWriteComplete	examples/wordcount/hasher.cc	/^  void onWriteComplete()$/;"	f	class:SendThrottler	file:
+op_	examples/memcached/client/bench.cc	/^  const Operation op_;$/;"	m	class:Client	file:
+openedFiles	muduo/base/ProcessInfo.cc	/^int ProcessInfo::openedFiles()$/;"	f	class:ProcessInfo
+openedFiles	muduo/net/inspect/ProcessInspector.cc	/^string ProcessInspector::openedFiles(HttpRequest::Method, const Inspector::ArgList&)$/;"	f	class:ProcessInspector
+operator !=	muduo/base/StringPiece.h	/^  bool operator!=(const StringPiece& x) const {$/;"	f	class:muduo::StringPiece
+operator ()	examples/memcached/server/MemcacheServer.h	/^    bool operator()(const ConstItemPtr& x, const ConstItemPtr& y) const$/;"	f	struct:MemcacheServer::Equal
+operator ()	examples/memcached/server/MemcacheServer.h	/^    size_t operator()(const ConstItemPtr& x) const$/;"	f	struct:MemcacheServer::Hash
+operator ()	examples/memcached/server/Session.cc	/^bool Session::SpaceSeparator::operator()(InputIterator& next, InputIterator end, Token& tok)$/;"	f	class:Session::SpaceSeparator
+operator ()	muduo/base/TimeZone.cc	/^  bool operator()(const Transition& lhs, const Transition& rhs) const$/;"	f	struct:muduo::detail::Comp
+operator <	muduo/base/Date.h	/^inline bool operator<(Date x, Date y)$/;"	f	namespace:muduo
+operator <	muduo/base/Timestamp.h	/^inline bool operator<(Timestamp lhs, Timestamp rhs)$/;"	f	namespace:muduo
+operator <<	muduo/base/LogStream.cc	/^LogStream& LogStream::operator<<(const void* p)$/;"	f	class:LogStream
+operator <<	muduo/base/LogStream.cc	/^LogStream& LogStream::operator<<(double v)$/;"	f	class:LogStream
+operator <<	muduo/base/LogStream.cc	/^LogStream& LogStream::operator<<(int v)$/;"	f	class:LogStream
+operator <<	muduo/base/LogStream.cc	/^LogStream& LogStream::operator<<(long long v)$/;"	f	class:LogStream
+operator <<	muduo/base/LogStream.cc	/^LogStream& LogStream::operator<<(long v)$/;"	f	class:LogStream
+operator <<	muduo/base/LogStream.cc	/^LogStream& LogStream::operator<<(short v)$/;"	f	class:LogStream
+operator <<	muduo/base/LogStream.cc	/^LogStream& LogStream::operator<<(unsigned int v)$/;"	f	class:LogStream
+operator <<	muduo/base/LogStream.cc	/^LogStream& LogStream::operator<<(unsigned long long v)$/;"	f	class:LogStream
+operator <<	muduo/base/LogStream.cc	/^LogStream& LogStream::operator<<(unsigned long v)$/;"	f	class:LogStream
+operator <<	muduo/base/LogStream.cc	/^LogStream& LogStream::operator<<(unsigned short v)$/;"	f	class:LogStream
+operator <<	muduo/base/LogStream.h	/^  self& operator<<(bool v)$/;"	f	class:muduo::LogStream
+operator <<	muduo/base/LogStream.h	/^  self& operator<<(char v)$/;"	f	class:muduo::LogStream
+operator <<	muduo/base/LogStream.h	/^  self& operator<<(const StringPiece& v)$/;"	f	class:muduo::LogStream
+operator <<	muduo/base/LogStream.h	/^  self& operator<<(const char* v)$/;"	f	class:muduo::LogStream
+operator <<	muduo/base/LogStream.h	/^  self& operator<<(const std::string& v)$/;"	f	class:muduo::LogStream
+operator <<	muduo/base/LogStream.h	/^  self& operator<<(const string& v)$/;"	f	class:muduo::LogStream
+operator <<	muduo/base/LogStream.h	/^  self& operator<<(float v)$/;"	f	class:muduo::LogStream
+operator <<	muduo/base/LogStream.h	/^inline LogStream& operator<<(LogStream& s, const Fmt& fmt)$/;"	f	namespace:muduo
+operator <<	muduo/base/Logging.cc	/^inline LogStream& operator<<(LogStream& s, T v)$/;"	f	namespace:muduo
+operator <<	muduo/base/Logging.cc	/^inline LogStream& operator<<(LogStream& s, const Logger::SourceFile& v)$/;"	f	namespace:muduo
+operator ==	muduo/base/Date.h	/^inline bool operator==(Date x, Date y)$/;"	f	namespace:muduo
+operator ==	muduo/base/StringPiece.h	/^  bool operator==(const StringPiece& x) const {$/;"	f	class:muduo::StringPiece
+operator ==	muduo/base/Timestamp.h	/^inline bool operator==(Timestamp lhs, Timestamp rhs)$/;"	f	namespace:muduo
+operator []	muduo/base/StringPiece.h	/^  char operator[](int i) const { return ptr_[i]; }$/;"	f	class:muduo::StringPiece
+options_	examples/memcached/server/MemcacheServer.h	/^  Options options_;$/;"	m	class:MemcacheServer
+os	examples/wordcount/slowsink.py	/^import os, socket, sys, time$/;"	i
+out_	examples/curl/download.cc	/^  FilePtr out_;$/;"	m	class:Downloader	file:
+out_	examples/curl/download.cc	/^  FilePtr out_;$/;"	m	class:Piece	file:
+output	examples/memcached/server/Item.cc	/^void Item::output(Buffer* out, bool needCas) const$/;"	f	class:Item
+output	examples/wordcount/gen.py	/^output = open('random_words', 'w')$/;"	v
+output	examples/wordcount/receiver.cc	/^  void output()$/;"	f	class:WordCountReceiver	file:
+output	muduo/net/tests/Buffer_unittest.cc	/^void output(Buffer&& buf, const void* inner)$/;"	f
+outputBuf_	examples/memcached/server/Session.h	/^  muduo::net::Buffer outputBuf_;$/;"	m	class:Session
+outputBuffer	muduo/net/TcpConnection.h	/^  Buffer* outputBuffer()$/;"	f	class:muduo::net::TcpConnection
+outputBuffer_	muduo/net/TcpConnection.h	/^  Buffer outputBuffer_; \/\/ FIXME: use list<Buffer> as output buffer.$/;"	m	class:muduo::net::TcpConnection
+outputFunc	muduo/base/tests/LogFile_test.cc	/^void outputFunc(const char* msg, int len)$/;"	f
+outstandings_	muduo/net/protorpc/RpcChannel.h	/^  std::map<int64_t, OutstandingCall> outstandings_;$/;"	m	class:muduo::net::RpcChannel
+overview	muduo/net/inspect/ProcessInspector.cc	/^string ProcessInspector::overview(HttpRequest::Method, const Inspector::ArgList&)$/;"	f	class:ProcessInspector
+owner	examples/cdns/Resolver.h	/^    Resolver* owner;$/;"	m	struct:cdns::Resolver::QueryData
+ownerLoop	muduo/net/Channel.h	/^  EventLoop* ownerLoop() { return loop_; }$/;"	f	class:muduo::net::Channel
+ownerLoop_	muduo/net/Poller.h	/^  EventLoop* ownerLoop_;$/;"	m	class:muduo::net::Poller
+owner_	examples/curl/Curl.h	/^  class Curl* owner_;$/;"	m	class:curl::Request	typeref:class:curl::Request::Curl
+owner_	examples/memcached/server/Session.h	/^  MemcacheServer* owner_;$/;"	m	class:Session
+owner_	examples/pingpong/client.cc	/^  Client* owner_;$/;"	m	class:Session	file:
+owner_	muduo/base/Mutex.h	/^    MutexLock& owner_;$/;"	m	class:muduo::MutexLock::UnassignGuard
+padding	examples/fastcgi/fastcgi.cc	/^  uint8_t padding;$/;"	m	struct:FastCgiCodec::RecordHeader	file:
+paramsStream_	examples/fastcgi/fastcgi.h	/^  muduo::net::Buffer paramsStream_;$/;"	m	class:FastCgiCodec
+params_	examples/fastcgi/fastcgi.h	/^  ParamMap params_;$/;"	m	class:FastCgiCodec
+parse	examples/protobuf/codec/codec.cc	/^MessagePtr ProtobufCodec::parse(const char* buf, int len, ErrorCode* error)$/;"	f	class:ProtobufCodec
+parse	muduo/net/protorpc/RpcCodec.cc	/^RpcCodec::ErrorCode RpcCodec::parse(const char* buf, int len, RpcMessage* message)$/;"	f	class:RpcCodec
+parseAllParams	examples/fastcgi/fastcgi.cc	/^bool FastCgiCodec::parseAllParams()$/;"	f	class:FastCgiCodec
+parseCommandLine	examples/memcached/server/server.cc	/^bool parseCommandLine(int argc, char* argv[], MemcacheServer::Options* options)$/;"	f
+parseMessage	examples/hub/codec.cc	/^ParseResult pubsub::parseMessage(Buffer* buf,$/;"	f	class:pubsub
+parseRequest	examples/fastcgi/fastcgi.cc	/^bool FastCgiCodec::parseRequest(Buffer* buf)$/;"	f	class:FastCgiCodec
+parseRequest	muduo/net/http/HttpServer.cc	/^bool parseRequest(Buffer* buf, HttpContext* context, Timestamp receiveTime)$/;"	f	namespace:muduo::net::detail
+passByConstReference	muduo/base/tests/Date_unittest.cc	/^void passByConstReference(const Date& x)$/;"	f
+passByConstReference	muduo/base/tests/Timestamp_unittest.cc	/^void passByConstReference(const Timestamp& x)$/;"	f
+passByValue	muduo/base/tests/Date_unittest.cc	/^void passByValue(Date x)$/;"	f
+passByValue	muduo/base/tests/Timestamp_unittest.cc	/^void passByValue(Timestamp x)$/;"	f
+path	muduo/net/http/HttpRequest.h	/^  const string& path() const$/;"	f	class:muduo::net::HttpRequest
+path_	muduo/net/http/HttpRequest.h	/^  string path_;$/;"	m	class:muduo::net::HttpRequest
+pcond_	muduo/base/Condition.h	/^  pthread_cond_t pcond_;$/;"	m	class:muduo::Condition
+peek	muduo/net/Buffer.h	/^  const char* peek() const$/;"	f	class:muduo::net::Buffer
+peekInt16	muduo/net/Buffer.h	/^  int16_t peekInt16() const$/;"	f	class:muduo::net::Buffer
+peekInt32	muduo/net/Buffer.h	/^  int32_t peekInt32() const$/;"	f	class:muduo::net::Buffer
+peekInt8	muduo/net/Buffer.h	/^  int8_t peekInt8() const$/;"	f	class:muduo::net::Buffer
+peerAddr_	muduo/net/TcpConnection.h	/^  InetAddress peerAddr_;$/;"	m	class:muduo::net::TcpConnection
+peerAddress	muduo/net/TcpConnection.h	/^  const InetAddress& peerAddress() { return peerAddr_; }$/;"	f	class:muduo::net::TcpConnection
+pending	examples/multiplexer/demux.cc	/^  Buffer pending;$/;"	m	struct:Entry	file:
+pendingFunctors_	muduo/net/EventLoop.h	/^  std::vector<Functor> pendingFunctors_; \/\/ @BuardedBy mutex_$/;"	m	class:muduo::net::EventLoop
+performanceInspector_	muduo/net/inspect/Inspector.h	/^  boost::scoped_ptr<PerformanceInspector> performanceInspector_;$/;"	m	class:muduo::net::Inspector
+pid	muduo/base/ProcessInfo.cc	/^pid_t ProcessInfo::pid()$/;"	f	class:ProcessInfo
+pid	muduo/net/inspect/ProcessInspector.cc	/^string ProcessInspector::pid(HttpRequest::Method, const Inspector::ArgList&)$/;"	f	class:ProcessInspector
+pidString	muduo/base/ProcessInfo.cc	/^string ProcessInfo::pidString()$/;"	f	class:ProcessInfo
+pieces_	examples/curl/download.cc	/^  boost::ptr_vector<Piece> pieces_;$/;"	m	class:Downloader	file:
+pkey_	muduo/base/ThreadLocal.h	/^  pthread_key_t pkey_;$/;"	m	class:muduo::ThreadLocal
+pkey_	muduo/base/ThreadLocalSingleton.h	/^    pthread_key_t pkey_;$/;"	m	class:muduo::ThreadLocalSingleton::Deleter
+pointer	muduo/base/ThreadLocalSingleton.h	/^  static T* pointer()$/;"	f	class:muduo::ThreadLocalSingleton
+policy_	examples/memcached/server/Session.h	/^  Item::UpdatePolicy policy_;$/;"	m	class:Session
+poll	muduo/net/poller/EPollPoller.cc	/^Timestamp EPollPoller::poll(int timeoutMs, ChannelList* activeChannels)$/;"	f	class:EPollPoller
+poll	muduo/net/poller/PollPoller.cc	/^Timestamp PollPoller::poll(int timeoutMs, ChannelList* activeChannels)$/;"	f	class:PollPoller
+pollReturnTime	muduo/net/EventLoop.h	/^  Timestamp pollReturnTime() const { return pollReturnTime_; }$/;"	f	class:muduo::net::EventLoop
+pollReturnTime_	muduo/net/EventLoop.h	/^  Timestamp pollReturnTime_;$/;"	m	class:muduo::net::EventLoop
+poller_	muduo/net/EventLoop.h	/^  boost::scoped_ptr<Poller> poller_;$/;"	m	class:muduo::net::EventLoop
+pollfds_	muduo/net/poller/PollPoller.h	/^  PollFdList pollfds_;$/;"	m	class:muduo::net::PollPoller
+ponce_	muduo/base/Singleton.h	/^  static pthread_once_t ponce_;$/;"	m	class:muduo::Singleton
+ponce_	muduo/base/Singleton.h	/^pthread_once_t Singleton<T>::ponce_ = PTHREAD_ONCE_INIT;$/;"	m	class:muduo::Singleton
+port	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/MockBackendServer.java	/^    private final int port;$/;"	f	class:MockBackendServer	file:
+port	examples/wordcount/slowsink.py	/^	port = int(sys.argv[3])$/;"	v
+port	examples/wordcount/slowsink.py	/^port = 2007$/;"	v
+portNetEndian	muduo/net/InetAddress.h	/^  uint16_t portNetEndian() const { return addr_.sin_port; }$/;"	f	class:muduo::net::InetAddress
+position	examples/idleconnection/sortedlist.cc	/^    WeakConnectionList::iterator position;$/;"	m	struct:EchoServer::Node	file:
+prepend	muduo/net/Buffer.h	/^  void prepend(const void* \/*restrict*\/ data, size_t len)$/;"	f	class:muduo::net::Buffer
+prependInt16	muduo/net/Buffer.h	/^  void prependInt16(int16_t x)$/;"	f	class:muduo::net::Buffer
+prependInt32	muduo/net/Buffer.h	/^  void prependInt32(int32_t x)$/;"	f	class:muduo::net::Buffer
+prependInt8	muduo/net/Buffer.h	/^  void prependInt8(int8_t x)$/;"	f	class:muduo::net::Buffer
+prependableBytes	muduo/net/Buffer.h	/^  size_t prependableBytes() const$/;"	f	class:muduo::net::Buffer
+prevRunningHandles_	examples/curl/Curl.h	/^  int prevRunningHandles_;$/;"	m	class:curl::Curl
+print	examples/asio/tutorial/timer2/timer.cc	/^void print()$/;"	f
+print	examples/asio/tutorial/timer3/timer.cc	/^void print(muduo::net::EventLoop* loop, int* count)$/;"	f
+print	examples/asio/tutorial/timer4/timer.cc	/^  void print()$/;"	f	class:Printer
+print	examples/protobuf/codec/codec_test.cc	/^void print(const Buffer& buf)$/;"	f
+print	muduo/base/tests/Fork_test.cc	/^void print()$/;"	f
+print	muduo/base/tests/SingletonThreadLocal_test.cc	/^void print()$/;"	f
+print	muduo/base/tests/ThreadLocal_test.cc	/^void print()$/;"	f
+print	muduo/base/tests/ThreadPool_test.cc	/^void print()$/;"	f
+print	muduo/net/tests/EventLoopThreadPool_unittest.cc	/^void print(EventLoop* p = NULL)$/;"	f
+print	muduo/net/tests/EventLoopThread_unittest.cc	/^void print(EventLoop* p = NULL)$/;"	f
+print	muduo/net/tests/TimerQueue_unittest.cc	/^void print(const char* msg)$/;"	f
+print1	examples/asio/tutorial/timer5/timer.cc	/^  void print1()$/;"	f	class:Printer
+print1	examples/asio/tutorial/timer6/timer.cc	/^  void print1()$/;"	f	class:Printer
+print2	examples/asio/tutorial/timer5/timer.cc	/^  void print2()$/;"	f	class:Printer
+print2	examples/asio/tutorial/timer6/timer.cc	/^  void print2()$/;"	f	class:Printer
+printActiveChannels	muduo/net/EventLoop.cc	/^void EventLoop::printActiveChannels() const$/;"	f	class:EventLoop
+printStatistics	examples/multiplexer/multiplexer.cc	/^  void printStatistics()$/;"	f	class:MultiplexServer	file:
+printString	muduo/base/tests/ThreadPool_test.cc	/^void printString(const std::string& str)$/;"	f
+printThroughput	examples/netty/discard/server.cc	/^  void printThroughput()$/;"	f	class:DiscardServer	file:
+printThroughput	examples/netty/echo/server.cc	/^  void printThroughput()$/;"	f	class:EchoServer	file:
+printThroughput	examples/simple/chargen/chargen.cc	/^void ChargenServer::printThroughput()$/;"	f	class:ChargenServer
+printTid	muduo/net/tests/TimerQueue_unittest.cc	/^void printTid()$/;"	f
+procStat	muduo/base/ProcessInfo.cc	/^string ProcessInfo::procStat()$/;"	f	class:ProcessInfo
+procStatus	muduo/base/ProcessInfo.cc	/^string ProcessInfo::procStatus()$/;"	f	class:ProcessInfo
+procStatus	muduo/net/inspect/ProcessInspector.cc	/^string ProcessInspector::procStatus(HttpRequest::Method, const Inspector::ArgList&)$/;"	f	class:ProcessInspector
+processFile	examples/wordcount/hasher.cc	/^void WordCountSender::processFile(const char* filename)$/;"	f	class:WordCountSender
+processInspector_	muduo/net/inspect/Inspector.h	/^  boost::scoped_ptr<ProcessInspector> processInspector_;$/;"	m	class:muduo::net::Inspector
+processRequest	examples/memcached/server/Session.cc	/^bool Session::processRequest(StringPiece request)$/;"	f	class:Session
+processRequest	examples/sudoku/server_basic.cc	/^  bool processRequest(const TcpConnectionPtr& conn, const string& request)$/;"	f	class:SudokuServer	file:
+processRequest	examples/sudoku/server_multiloop.cc	/^  bool processRequest(const TcpConnectionPtr& conn, const string& request)$/;"	f	class:SudokuServer	file:
+processRequest	examples/sudoku/server_threadpool.cc	/^  bool processRequest(const TcpConnectionPtr& conn, const string& request)$/;"	f	class:SudokuServer	file:
+processRequestLine	muduo/net/http/HttpServer.cc	/^bool processRequestLine(const char* begin, const char* end, HttpContext* context)$/;"	f	namespace:muduo::net::detail
+procname	muduo/base/ProcessInfo.cc	/^string ProcessInfo::procname()$/;"	f	class:ProcessInfo
+profile	muduo/net/inspect/PerformanceInspector.cc	/^string PerformanceInspector::profile(HttpRequest::Method, const Inspector::ArgList&)$/;"	f	class:PerformanceInspector
+protobuf	muduo/net/protorpc/RpcChannel.h	/^namespace protobuf {$/;"	n	namespace:google
+protobuf	muduo/net/protorpc/RpcServer.h	/^namespace protobuf {$/;"	n	namespace:google
+protocol_	examples/memcached/server/Session.h	/^  Protocol protocol_;$/;"	m	class:Session
+pthreadId_	muduo/base/Thread.h	/^  pthread_t  pthreadId_;$/;"	m	class:muduo::Thread
+ptr_	muduo/base/StringPiece.h	/^  const char*   ptr_;$/;"	m	class:muduo::StringPiece
+publish	examples/hub/hub.cc	/^  void publish(const string& content, Timestamp time)$/;"	f	class:pubsub::Topic
+publish	examples/hub/pubsub.cc	/^bool PubSubClient::publish(const string& topic, const string& content)$/;"	f	class:PubSubClient
+pubsub	examples/hub/codec.h	/^namespace pubsub$/;"	n
+pubsub	examples/hub/hub.cc	/^namespace pubsub$/;"	n	file:
+pubsub	examples/hub/pubsub.h	/^namespace pubsub$/;"	n
+put	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/EventQueue.java	/^    public void put(Event e) {$/;"	m	class:EventQueue
+put	muduo/base/BlockingQueue.h	/^  void put(const T& x)$/;"	f	class:muduo::BlockingQueue
+put	muduo/base/BoundedBlockingQueue.h	/^  void put(const T& x)$/;"	f	class:muduo::BoundedBlockingQueue
+put_left	examples/sudoku/sudoku.cc	/^    void put_left(Column* old, Column* nnew)$/;"	f	class:SudokuSolver	file:
+put_up	examples/sudoku/sudoku.cc	/^    void put_up(Column* old, Node* nnew)$/;"	f	class:SudokuSolver	file:
+query	muduo/net/http/HttpRequest.h	/^  const string& query() const$/;"	f	class:muduo::net::HttpRequest
+query_	muduo/net/http/HttpRequest.h	/^  string query_;$/;"	m	class:muduo::net::HttpRequest
+queue	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/EventQueue.java	/^    private BlockingDeque<Event> queue = new LinkedBlockingDeque<Event>();$/;"	f	class:EventQueue	file:
+queue	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/MockBackendServer.java	/^    private final EventQueue queue;$/;"	f	class:MockBackendServer	file:
+queue	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/MockClient.java	/^    private final EventQueue queue;$/;"	f	class:MockClient	file:
+queue	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/MultiplexerTest.java	/^    private EventQueue queue;$/;"	f	class:MultiplexerTest	file:
+queue	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/TestCase.java	/^    protected EventQueue queue;$/;"	f	class:TestCase
+queueInLoop	muduo/net/EventLoop.cc	/^void EventLoop::queueInLoop(Functor&& cb)$/;"	f	class:EventLoop
+queueInLoop	muduo/net/EventLoop.cc	/^void EventLoop::queueInLoop(const Functor& cb)$/;"	f	class:EventLoop
+queue_	muduo/base/BlockingQueue.h	/^  std::deque<T>     queue_;$/;"	m	class:muduo::BlockingQueue
+queue_	muduo/base/BoundedBlockingQueue.h	/^  boost::circular_buffer<T>  queue_;$/;"	m	class:muduo::BoundedBlockingQueue
+queue_	muduo/base/ThreadPool.h	/^  std::deque<Task> queue_;$/;"	m	class:muduo::ThreadPool
+queue_	muduo/base/tests/BlockingQueue_bench.cc	/^  muduo::BlockingQueue<muduo::Timestamp> queue_;$/;"	m	class:Bench	file:
+queue_	muduo/base/tests/BlockingQueue_test.cc	/^  muduo::BlockingQueue<std::string> queue_;$/;"	m	class:Test	file:
+queue_	muduo/base/tests/BoundedBlockingQueue_test.cc	/^  muduo::BoundedBlockingQueue<std::string> queue_;$/;"	m	class:Test	file:
+quit	examples/cdns/dns.cc	/^void quit()$/;"	f
+quit	examples/pingpong/client.cc	/^  void quit()$/;"	f	class:Client	file:
+quit	muduo/net/EventLoop.cc	/^void EventLoop::quit()$/;"	f	class:EventLoop
+quit_	muduo/net/EventLoop.h	/^  bool quit_; \/* atomic *\/$/;"	m	class:muduo::net::EventLoop
+random	examples/filetransfer/loadtest/Client.java	/^        Random random = new Random();$/;"	f	class:Client.PipelineFactory
+random	examples/wordcount/gen.py	/^import random$/;"	i
+range_	examples/curl/download.cc	/^  std::string range_;$/;"	m	class:Piece	file:
+read	examples/memcached/server/Session.cc	/^  bool read(T* val)$/;"	f	struct:Session::Reader
+read	muduo/net/SocketsOps.cc	/^ssize_t sockets::read(int sockfd, void *buf, size_t count)$/;"	f	class:sockets
+readBytes	muduo/base/TimeZone.cc	/^  string readBytes(int n)$/;"	f	class:muduo::detail::File
+readCallback	examples/pingpong/bench.cc	/^void readCallback(Timestamp, int fd, int idx)$/;"	f
+readCallback_	muduo/net/Channel.h	/^  ReadEventCallback readCallback_;$/;"	m	class:muduo::net::Channel
+readFd	muduo/net/Buffer.cc	/^ssize_t Buffer::readFd(int fd, int* savedErrno)$/;"	f	class:Buffer
+readFile	examples/filetransfer/download.cc	/^string readFile(const char* filename)$/;"	f
+readFile	muduo/base/FileUtil.h	/^  int readFile(StringPiece filename,$/;"	f	namespace:muduo::FileUtil
+readInput	examples/sudoku/client.cc	/^InputPtr readInput(std::istream& in)$/;"	f
+readInt16	examples/fastcgi/fastcgi.cc	/^uint16_t readInt16(const void* p)$/;"	f
+readInt16	muduo/net/Buffer.h	/^  int16_t readInt16()$/;"	f	class:muduo::net::Buffer
+readInt32	muduo/base/TimeZone.cc	/^  int32_t readInt32()$/;"	f	class:muduo::detail::File
+readInt32	muduo/net/Buffer.h	/^  int32_t readInt32()$/;"	f	class:muduo::net::Buffer
+readInt8	muduo/net/Buffer.h	/^  int8_t readInt8()$/;"	f	class:muduo::net::Buffer
+readLen	examples/fastcgi/fastcgi.cc	/^uint32_t FastCgiCodec::readLen()$/;"	f	class:FastCgiCodec
+readTimeZoneFile	muduo/base/TimeZone.cc	/^bool readTimeZoneFile(const char* zonefile, struct TimeZone::Data* data)$/;"	f	namespace:muduo::detail
+readTimerfd	muduo/net/TimerQueue.cc	/^void readTimerfd(int timerfd, Timestamp now)$/;"	f	namespace:muduo::net::detail
+readToBuffer	muduo/base/FileUtil.cc	/^int FileUtil::SmallFile::readToBuffer(int* size)$/;"	f	class:FileUtil::SmallFile
+readToString	muduo/base/FileUtil.cc	/^int FileUtil::SmallFile::readToString(int maxSize,$/;"	f	class:FileUtil::SmallFile
+readUInt8	muduo/base/TimeZone.cc	/^  uint8_t readUInt8()$/;"	f	class:muduo::detail::File
+readableBytes	muduo/net/Buffer.h	/^  size_t readableBytes() const$/;"	f	class:muduo::net::Buffer
+readerIndex_	muduo/net/Buffer.h	/^  size_t readerIndex_;$/;"	m	class:muduo::net::Buffer
+readv	muduo/net/SocketsOps.cc	/^ssize_t sockets::readv(int sockfd, const struct iovec *iov, int iovcnt)$/;"	f	class:sockets
+receiveHeaders	muduo/net/http/HttpContext.h	/^  void receiveHeaders()$/;"	f	class:muduo::net::HttpContext
+receiveRequestLine	muduo/net/http/HttpContext.h	/^  void receiveRequestLine()$/;"	f	class:muduo::net::HttpContext
+receiveTime	examples/asio/chat/loadtest.cc	/^  Timestamp receiveTime() const { return receiveTime_; }$/;"	f	class:ChatClient
+receiveTime	muduo/net/http/HttpRequest.h	/^  Timestamp receiveTime() const$/;"	f	class:muduo::net::HttpRequest
+receiveTime_	examples/asio/chat/loadtest.cc	/^  Timestamp receiveTime_;$/;"	m	class:ChatClient	file:
+receiveTime_	muduo/net/http/HttpRequest.h	/^  Timestamp receiveTime_;$/;"	m	class:muduo::net::HttpRequest
+receiveValue	examples/memcached/server/Session.cc	/^void Session::receiveValue(muduo::net::Buffer* buf)$/;"	f	class:Session
+received	examples/filetransfer/loadtest/Handler.java	/^    private int received = 0;$/;"	f	class:Handler	file:
+receivedBytes_	examples/memcached/server/Item.h	/^  int            receivedBytes_;  \/\/ FIXME: remove this member$/;"	m	class:Item
+receivedMessages_	examples/multiplexer/multiplexer.cc	/^  AtomicInt64 receivedMessages_;$/;"	m	class:MultiplexServer	file:
+receivedMessages_	examples/netty/discard/server.cc	/^  AtomicInt64 receivedMessages_;$/;"	m	class:DiscardServer	file:
+receivedMessages_	examples/netty/echo/server.cc	/^  AtomicInt64 receivedMessages_;$/;"	m	class:EchoServer	file:
+reconnect	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/MockClient.java	/^        private void reconnect() {$/;"	m	class:MockClient.Handler	file:
+redirections	examples/shorturl/shorturl.cc	/^std::map<string, string> redirections;$/;"	v
+redoCheckSum	examples/protobuf/codec/codec_test.cc	/^void redoCheckSum(string& data, int len)$/;"	f
+registerCommands	muduo/net/inspect/PerformanceInspector.cc	/^void PerformanceInspector::registerCommands(Inspector* ins)$/;"	f	class:PerformanceInspector
+registerCommands	muduo/net/inspect/ProcessInspector.cc	/^void ProcessInspector::registerCommands(Inspector* ins)$/;"	f	class:ProcessInspector
+registerMessageCallback	examples/protobuf/codec/dispatcher.h	/^  void registerMessageCallback(const typename CallbackT<T>::ProtobufMessageTCallback& callback)$/;"	f	class:ProtobufDispatcher
+registerMessageCallback	examples/protobuf/codec/dispatcher_lite.h	/^  void registerMessageCallback(const google::protobuf::Descriptor* desc,$/;"	f	class:ProtobufDispatcherLite
+registerService	muduo/net/protorpc/RpcServer.cc	/^void RpcServer::registerService(google::protobuf::Service* service)$/;"	f	class:RpcServer
+rel_exptime	examples/memcached/server/Item.h	/^  int rel_exptime() const$/;"	f	class:Item
+rel_exptime_	examples/memcached/server/Item.h	/^  const int      rel_exptime_;$/;"	m	class:Item
+remoteAddress	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/MockClient.java	/^    private final InetSocketAddress remoteAddress;$/;"	f	class:MockClient	file:
+remove	examples/hub/hub.cc	/^  void remove(const TcpConnectionPtr& conn)$/;"	f	class:pubsub::Topic
+remove	muduo/net/Channel.cc	/^void Channel::remove()$/;"	f	class:Channel
+removeAndResetChannel	muduo/net/Connector.cc	/^int Connector::removeAndResetChannel()$/;"	f	class:Connector
+removeChannel	examples/curl/Curl.cc	/^void Request::removeChannel()$/;"	f	class:Request
+removeChannel	muduo/net/EventLoop.cc	/^void EventLoop::removeChannel(Channel* channel)$/;"	f	class:EventLoop
+removeChannel	muduo/net/poller/EPollPoller.cc	/^void EPollPoller::removeChannel(Channel* channel)$/;"	f	class:EPollPoller
+removeChannel	muduo/net/poller/PollPoller.cc	/^void PollPoller::removeChannel(Channel* channel)$/;"	f	class:PollPoller
+removeConnection	muduo/net/TcpClient.cc	/^void TcpClient::removeConnection(const TcpConnectionPtr& conn)$/;"	f	class:TcpClient
+removeConnection	muduo/net/TcpClient.cc	/^void removeConnection(EventLoop* loop, const TcpConnectionPtr& conn)$/;"	f	namespace:muduo::net::detail
+removeConnection	muduo/net/TcpServer.cc	/^void TcpServer::removeConnection(const TcpConnectionPtr& conn)$/;"	f	class:TcpServer
+removeConnectionInLoop	muduo/net/TcpServer.cc	/^void TcpServer::removeConnectionInLoop(const TcpConnectionPtr& conn)$/;"	f	class:TcpServer
+removeConnector	muduo/net/TcpClient.cc	/^void removeConnector(const ConnectorPtr& connector)$/;"	f	namespace:muduo::net::detail
+remove_prefix	muduo/base/StringPiece.h	/^  void remove_prefix(int n) {$/;"	f	class:muduo::StringPiece
+remove_suffix	muduo/base/StringPiece.h	/^  void remove_suffix(int n) {$/;"	f	class:muduo::StringPiece
+repeat	muduo/net/Timer.h	/^  bool repeat() const { return repeat_; }$/;"	f	class:muduo::net::Timer
+repeat_	muduo/net/Timer.h	/^  const bool repeat_;$/;"	m	class:muduo::net::Timer
+replied	examples/protobuf/rpcbench/client.cc	/^  void replied(echo::EchoResponse* resp)$/;"	f	class:RpcClient	file:
+reply	examples/memcached/server/Session.cc	/^void Session::reply(muduo::StringPiece msg)$/;"	f	class:Session
+req2_	examples/curl/download.cc	/^  curl::RequestPtr req2_;$/;"	m	class:Downloader	file:
+req_	examples/curl/download.cc	/^  curl::RequestPtr req_;$/;"	m	class:Downloader	file:
+req_	examples/curl/download.cc	/^  curl::RequestPtr req_;$/;"	m	class:Piece	file:
+request	muduo/net/http/HttpContext.h	/^  HttpRequest& request()$/;"	f	class:muduo::net::HttpContext
+request	muduo/net/http/HttpContext.h	/^  const HttpRequest& request() const$/;"	f	class:muduo::net::HttpContext
+request_	muduo/net/http/HttpContext.h	/^  HttpRequest request_;$/;"	m	class:muduo::net::HttpContext
+requestsProcessed_	examples/memcached/server/Session.h	/^  size_t requestsProcessed_;$/;"	m	class:Session
+requests_	examples/memcached/client/bench.cc	/^  const int requests_;$/;"	m	class:Client	file:
+require_32_bit_integer_at_least	muduo/base/Date.cc	/^char require_32_bit_integer_at_least[sizeof(int) >= sizeof(int32_t) ? 1 : -1];$/;"	m	namespace:muduo::detail	file:
+reset	examples/memcached/server/Session.h	/^    void reset() {}$/;"	f	struct:Session::SpaceSeparator
+reset	muduo/base/LogStream.h	/^  void reset() { cur_ = data_; }$/;"	f	class:muduo::detail::FixedBuffer
+reset	muduo/net/TimerQueue.cc	/^void TimerQueue::reset(const std::vector<Entry>& expired, Timestamp now)$/;"	f	class:TimerQueue
+reset	muduo/net/http/HttpContext.h	/^  void reset()$/;"	f	class:muduo::net::HttpContext
+resetBuffer	muduo/base/LogStream.h	/^  void resetBuffer() { buffer_.reset(); }$/;"	f	class:muduo::LogStream
+resetChannel	muduo/net/Connector.cc	/^void Connector::resetChannel()$/;"	f	class:Connector
+resetKey	examples/memcached/server/Item.cc	/^void Item::resetKey(StringPiece k)$/;"	f	class:Item
+resetRequest	examples/memcached/server/Session.cc	/^void Session::resetRequest()$/;"	f	class:Session
+resetTimerfd	muduo/net/TimerQueue.cc	/^void resetTimerfd(int timerfd, Timestamp expiration)$/;"	f	namespace:muduo::net::detail
+resolve	examples/cdns/Resolver.cc	/^bool Resolver::resolve(const StringPiece& hostname, const Callback& cb)$/;"	f	class:Resolver
+resolve	examples/cdns/dns.cc	/^void resolve(Resolver* res, const string& host)$/;"	f
+resolve	examples/protobuf/resolver/client.cc	/^  void resolve(const std::string& host)$/;"	f	class:RpcClient	file:
+resolveCallback	examples/cdns/dns.cc	/^void resolveCallback(const string& host, const InetAddress& addr)$/;"	f
+resolved	examples/protobuf/resolver/client.cc	/^  void resolved(resolver::ResolveResponse* resp, std::string host)$/;"	f	class:RpcClient	file:
+resolver	examples/protobuf/resolver/server.cc	/^namespace resolver$/;"	n	file:
+resolver_	examples/protobuf/resolver/server.cc	/^  cdns::Resolver resolver_;$/;"	m	class:resolver::ResolverServiceImpl	file:
+respond	examples/fastcgi/fastcgi.cc	/^void FastCgiCodec::respond(Buffer* response)$/;"	f	class:FastCgiCodec
+response	muduo/net/protorpc/RpcChannel.h	/^    ::google::protobuf::Message* response;$/;"	m	struct:muduo::net::RpcChannel::OutstandingCall
+restart	muduo/net/Connector.cc	/^void Connector::restart()$/;"	f	class:Connector
+restart	muduo/net/Timer.cc	/^void Timer::restart(Timestamp now)$/;"	f	class:Timer
+retrieve	muduo/net/Buffer.h	/^  void retrieve(size_t len)$/;"	f	class:muduo::net::Buffer
+retrieveAll	muduo/net/Buffer.h	/^  void retrieveAll()$/;"	f	class:muduo::net::Buffer
+retrieveAllAsString	muduo/net/Buffer.h	/^  string retrieveAllAsString()$/;"	f	class:muduo::net::Buffer
+retrieveAsString	muduo/net/Buffer.h	/^  string retrieveAsString(size_t len)$/;"	f	class:muduo::net::Buffer
+retrieveInt16	muduo/net/Buffer.h	/^  void retrieveInt16()$/;"	f	class:muduo::net::Buffer
+retrieveInt32	muduo/net/Buffer.h	/^  void retrieveInt32()$/;"	f	class:muduo::net::Buffer
+retrieveInt8	muduo/net/Buffer.h	/^  void retrieveInt8()$/;"	f	class:muduo::net::Buffer
+retrieveUntil	muduo/net/Buffer.h	/^  void retrieveUntil(const char* end)$/;"	f	class:muduo::net::Buffer
+retry	muduo/net/Connector.cc	/^void Connector::retry(int sockfd)$/;"	f	class:Connector
+retryDelayMs_	muduo/net/Connector.h	/^  int retryDelayMs_;$/;"	m	class:muduo::net::Connector
+retry_	muduo/net/TcpClient.h	/^  bool retry_;   \/\/ atmoic$/;"	m	class:muduo::net::TcpClient
+reventsToString	muduo/net/Channel.cc	/^string Channel::reventsToString() const$/;"	f	class:Channel
+revents_	muduo/net/Channel.h	/^  int        revents_;$/;"	m	class:muduo::net::Channel
+right	examples/sudoku/sudoku.cc	/^    Node* right;$/;"	m	struct:Node	file:
+rollFile	muduo/base/LogFile.cc	/^void LogFile::rollFile()$/;"	f	class:LogFile
+rollSize_	muduo/base/AsyncLogging.h	/^  size_t rollSize_;$/;"	m	class:muduo::AsyncLogging
+rollSize_	muduo/base/LogFile.h	/^  const size_t rollSize_;$/;"	m	class:muduo::LogFile
+root_	examples/sudoku/sudoku.cc	/^    Column* root_;$/;"	m	class:SudokuSolver	file:
+run	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/MultiplexerTest.java	/^    private void run() {$/;"	m	class:MultiplexerTest	file:
+run	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/TestCase.java	/^    public abstract void run();$/;"	m	class:TestCase
+run	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/testcase/TestOneClientBackendSend.java	/^    public void run() {$/;"	m	class:TestOneClientBackendSend
+run	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/testcase/TestOneClientBothSend.java	/^    public void run() {$/;"	m	class:TestOneClientBothSend
+run	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/testcase/TestOneClientNoData.java	/^    public void run() {$/;"	m	class:TestOneClientNoData
+run	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/testcase/TestOneClientSend.java	/^    public void run() {$/;"	m	class:TestOneClientSend
+run	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/testcase/TestTwoClients.java	/^    public void run() {$/;"	m	class:TestTwoClients
+run	muduo/base/ThreadPool.cc	/^void ThreadPool::run(Task&& task)$/;"	f	class:ThreadPool
+run	muduo/base/ThreadPool.cc	/^void ThreadPool::run(const Task& task)$/;"	f	class:ThreadPool
+run	muduo/base/tests/BlockingQueue_bench.cc	/^  void run(int times)$/;"	f	class:Bench
+run	muduo/base/tests/BlockingQueue_test.cc	/^  void run(int times)$/;"	f	class:Test
+run	muduo/base/tests/BoundedBlockingQueue_test.cc	/^  void run(int times)$/;"	f	class:Test
+run	muduo/net/Timer.h	/^  void run() const$/;"	f	class:muduo::net::Timer
+runAfter	muduo/net/EventLoop.cc	/^TimerId EventLoop::runAfter(double delay, TimerCallback&& cb)$/;"	f	class:EventLoop
+runAfter	muduo/net/EventLoop.cc	/^TimerId EventLoop::runAfter(double delay, const TimerCallback& cb)$/;"	f	class:EventLoop
+runAt	muduo/net/EventLoop.cc	/^TimerId EventLoop::runAt(const Timestamp& time, TimerCallback&& cb)$/;"	f	class:EventLoop
+runAt	muduo/net/EventLoop.cc	/^TimerId EventLoop::runAt(const Timestamp& time, const TimerCallback& cb)$/;"	f	class:EventLoop
+runClient	examples/roundtrip/roundtrip.cc	/^void runClient(const char* ip, uint16_t port)$/;"	f
+runClient	examples/roundtrip/roundtrip_udp.cc	/^void runClient(const char* ip, uint16_t port)$/;"	f
+runClient	examples/sudoku/client.cc	/^void runClient(std::istream& in, const InetAddress& serverAddr, int conn)$/;"	f
+runEvery	muduo/net/EventLoop.cc	/^TimerId EventLoop::runEvery(double interval, TimerCallback&& cb)$/;"	f	class:EventLoop
+runEvery	muduo/net/EventLoop.cc	/^TimerId EventLoop::runEvery(double interval, const TimerCallback& cb)$/;"	f	class:EventLoop
+runInLoop	muduo/net/EventLoop.cc	/^void EventLoop::runInLoop(Functor&& cb)$/;"	f	class:EventLoop
+runInLoop	muduo/net/EventLoop.cc	/^void EventLoop::runInLoop(const Functor& cb)$/;"	f	class:EventLoop
+runInThread	muduo/base/Thread.cc	/^  void runInThread()$/;"	f	struct:muduo::detail::ThreadData
+runInThread	muduo/base/ThreadPool.cc	/^void ThreadPool::runInThread()$/;"	f	class:ThreadPool
+runLocal	examples/sudoku/client.cc	/^void runLocal(std::istream& in)$/;"	f
+runOnce	examples/pingpong/bench.cc	/^std::pair<int, int> runOnce()$/;"	f
+runServer	examples/roundtrip/roundtrip.cc	/^void runServer(uint16_t port)$/;"	f
+runServer	examples/roundtrip/roundtrip_udp.cc	/^void runServer(uint16_t port)$/;"	f
+runningHandles_	examples/curl/Curl.h	/^  int runningHandles_;$/;"	m	class:curl::Curl
+running_	muduo/base/AsyncLogging.h	/^  bool running_;$/;"	m	class:muduo::AsyncLogging
+running_	muduo/base/ThreadPool.h	/^  bool running_;$/;"	m	class:muduo::ThreadPool
+s_numCreated_	muduo/net/Timer.h	/^  static AtomicInt64 s_numCreated_;$/;"	m	class:muduo::net::Timer
+sameType	muduo/base/Thread.cc	/^  const bool sameType = boost::is_same<int, pid_t>::value;$/;"	m	namespace:muduo::CurrentThread	file:
+scanDir	muduo/base/ProcessInfo.cc	/^int scanDir(const char *dirpath, int (*filter)(const struct dirent *))$/;"	f	namespace:muduo::detail
+secondsSinceEpoch	muduo/base/Timestamp.h	/^  time_t secondsSinceEpoch() const$/;"	f	class:muduo::Timestamp
+self	muduo/base/LogStream.h	/^  typedef LogStream self;$/;"	t	class:muduo::LogStream
+send	examples/asio/chat/codec.h	/^  void send(muduo::net::TcpConnection* conn,$/;"	f	class:LengthHeaderCodec
+send	examples/asio/chat/loadtest.cc	/^  void send()$/;"	f	class:ChatClient	file:
+send	examples/hub/pubsub.cc	/^bool PubSubClient::send(const string& message)$/;"	f	class:PubSubClient
+send	examples/memcached/client/bench.cc	/^  void send()$/;"	f	class:Client
+send	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/MockClient.java	/^    public ChannelBuffer send(String str) {$/;"	m	class:MockClient
+send	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/MockClient.java	/^    public void send(ChannelBuffer buf) {$/;"	m	class:MockClient
+send	examples/protobuf/codec/codec.h	/^  void send(const muduo::net::TcpConnectionPtr& conn,$/;"	f	class:ProtobufCodec
+send	examples/wordcount/hasher.cc	/^  void send(const string& word, int64_t count)$/;"	f	class:SendThrottler
+send	muduo/net/TcpConnection.cc	/^void TcpConnection::send(Buffer* buf)$/;"	f	class:TcpConnection
+send	muduo/net/TcpConnection.cc	/^void TcpConnection::send(const StringPiece& message)$/;"	f	class:TcpConnection
+send	muduo/net/TcpConnection.cc	/^void TcpConnection::send(const void* data, size_t len)$/;"	f	class:TcpConnection
+send	muduo/net/protorpc/RpcCodec.cc	/^void RpcCodec::send(const TcpConnectionPtr& conn,$/;"	f	class:RpcCodec
+sendBackendBuffer	examples/multiplexer/multiplexer.cc	/^  void sendBackendBuffer(int id, Buffer* buf)$/;"	f	class:MultiplexServer	file:
+sendBackendBuffer	examples/multiplexer/multiplexer_simple.cc	/^  void sendBackendBuffer(int id, Buffer* buf)$/;"	f	class:MultiplexServer	file:
+sendBackendPacket	examples/multiplexer/multiplexer.cc	/^  void sendBackendPacket(int id, Buffer* buf)$/;"	f	class:MultiplexServer	file:
+sendBackendPacket	examples/multiplexer/multiplexer_simple.cc	/^  void sendBackendPacket(int id, Buffer* buf)$/;"	f	class:MultiplexServer	file:
+sendBackendString	examples/multiplexer/multiplexer.cc	/^  void sendBackendString(int id, const string& msg)$/;"	f	class:MultiplexServer	file:
+sendBackendString	examples/multiplexer/multiplexer_simple.cc	/^  void sendBackendString(int id, const string& msg)$/;"	f	class:MultiplexServer	file:
+sendInLoop	muduo/net/TcpConnection.cc	/^void TcpConnection::sendInLoop(const StringPiece& message)$/;"	f	class:TcpConnection
+sendInLoop	muduo/net/TcpConnection.cc	/^void TcpConnection::sendInLoop(const void* data, size_t len)$/;"	f	class:TcpConnection
+sendMyTime	examples/roundtrip/roundtrip.cc	/^void sendMyTime()$/;"	f
+sendMyTime	examples/roundtrip/roundtrip_udp.cc	/^void sendMyTime(int sockfd)$/;"	f
+sendRequest	examples/protobuf/rpcbench/client.cc	/^  void sendRequest()$/;"	f	class:RpcClient
+sendServerPacket	examples/multiplexer/demux.cc	/^  void sendServerPacket(int connId, Buffer* buf)$/;"	f	class:DemuxServer
+sendToClient	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/MockBackendServer.java	/^    public ChannelBuffer sendToClient(int whichClient, String str) {$/;"	m	class:MockBackendServer
+sendToClient	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/MockBackendServer.java	/^    public void sendToClient(int whichClient, ChannelBuffer data) {$/;"	m	class:MockBackendServer
+sendToClient	examples/multiplexer/multiplexer.cc	/^  void sendToClient(Buffer* buf)$/;"	f	class:MultiplexServer	file:
+sendToClient	examples/multiplexer/multiplexer_simple.cc	/^  void sendToClient(Buffer* buf)$/;"	f	class:MultiplexServer	file:
+senders_	examples/wordcount/receiver.cc	/^  int senders_;$/;"	m	class:WordCountReceiver	file:
+sent_	examples/memcached/client/bench.cc	/^  int sent_;$/;"	m	class:Client	file:
+sequence	muduo/net/Timer.h	/^  int64_t sequence() const { return sequence_; }$/;"	f	class:muduo::net::Timer
+sequence_	muduo/net/Timer.h	/^  const int64_t sequence_;$/;"	m	class:muduo::net::Timer
+sequence_	muduo/net/TimerId.h	/^  int64_t sequence_;$/;"	m	class:muduo::net::TimerId
+serialVersionUID	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/TestFailedException.java	/^    private static final long serialVersionUID = 1982L;$/;"	f	class:TestFailedException	file:
+serverAddr_	muduo/net/Connector.h	/^  InetAddress serverAddr_;$/;"	m	class:muduo::net::Connector
+serverAddress	muduo/net/Connector.h	/^  const InetAddress& serverAddress() const { return serverAddr_; }$/;"	f	class:muduo::net::Connector
+serverConn_	examples/multiplexer/demux.cc	/^  TcpConnectionPtr serverConn_;$/;"	m	class:DemuxServer	file:
+serverConn_	examples/socks4a/tunnel.h	/^  muduo::net::TcpConnectionPtr serverConn_;$/;"	m	class:Tunnel
+serverConnectionCallback	examples/roundtrip/roundtrip.cc	/^void serverConnectionCallback(const TcpConnectionPtr& conn)$/;"	f
+serverMessageCallback	examples/roundtrip/roundtrip.cc	/^void serverMessageCallback(const TcpConnectionPtr& conn,$/;"	f
+serverReadCallback	examples/roundtrip/roundtrip_udp.cc	/^void serverReadCallback(int sockfd, muduo::Timestamp receiveTime)$/;"	f
+server_	examples/asio/chat/server.cc	/^  TcpServer server_;$/;"	m	class:ChatServer	file:
+server_	examples/asio/chat/server_threaded.cc	/^  TcpServer server_;$/;"	m	class:ChatServer	file:
+server_	examples/asio/chat/server_threaded_efficient.cc	/^  TcpServer server_;$/;"	m	class:ChatServer	file:
+server_	examples/asio/chat/server_threaded_highperformance.cc	/^  TcpServer server_;$/;"	m	class:ChatServer	file:
+server_	examples/hub/hub.cc	/^  TcpServer server_;$/;"	m	class:pubsub::PubSubServer	file:
+server_	examples/idleconnection/echo.h	/^  muduo::net::TcpServer server_;$/;"	m	class:EchoServer
+server_	examples/idleconnection/sortedlist.cc	/^  TcpServer server_;$/;"	m	class:EchoServer	file:
+server_	examples/maxconnection/echo.h	/^  muduo::net::TcpServer server_;$/;"	m	class:EchoServer
+server_	examples/memcached/server/MemcacheServer.h	/^  muduo::net::TcpServer server_;$/;"	m	class:MemcacheServer
+server_	examples/multiplexer/demux.cc	/^  TcpServer server_;$/;"	m	class:DemuxServer	file:
+server_	examples/multiplexer/multiplexer.cc	/^  TcpServer server_;$/;"	m	class:MultiplexServer	file:
+server_	examples/multiplexer/multiplexer_simple.cc	/^  TcpServer server_;$/;"	m	class:MultiplexServer	file:
+server_	examples/netty/discard/server.cc	/^  TcpServer server_;$/;"	m	class:DiscardServer	file:
+server_	examples/netty/echo/server.cc	/^  TcpServer server_;$/;"	m	class:EchoServer	file:
+server_	examples/protobuf/codec/server.cc	/^  TcpServer server_;$/;"	m	class:QueryServer	file:
+server_	examples/simple/chargen/chargen.h	/^  muduo::net::TcpServer server_;$/;"	m	class:ChargenServer
+server_	examples/simple/daytime/daytime.h	/^  muduo::net::TcpServer server_;$/;"	m	class:DaytimeServer
+server_	examples/simple/discard/discard.h	/^  muduo::net::TcpServer server_;$/;"	m	class:DiscardServer
+server_	examples/simple/echo/echo.h	/^  muduo::net::TcpServer server_;$/;"	m	class:EchoServer
+server_	examples/simple/time/time.h	/^  muduo::net::TcpServer server_;$/;"	m	class:TimeServer
+server_	examples/sudoku/server_basic.cc	/^  TcpServer server_;$/;"	m	class:SudokuServer	file:
+server_	examples/sudoku/server_multiloop.cc	/^  TcpServer server_;$/;"	m	class:SudokuServer	file:
+server_	examples/sudoku/server_threadpool.cc	/^  TcpServer server_;$/;"	m	class:SudokuServer	file:
+server_	examples/wordcount/receiver.cc	/^  TcpServer server_;$/;"	m	class:WordCountReceiver	file:
+server_	muduo/net/http/HttpServer.h	/^  TcpServer server_;$/;"	m	class:muduo::net::HttpServer
+server_	muduo/net/inspect/Inspector.h	/^  HttpServer server_;$/;"	m	class:muduo::net::Inspector
+server_	muduo/net/protorpc/RpcServer.h	/^  TcpServer server_;$/;"	m	class:muduo::net::RpcServer
+server_	muduo/net/tests/EchoServer_unittest.cc	/^  TcpServer server_;$/;"	m	class:EchoServer	file:
+server_socket	examples/wordcount/slowsink.py	/^	server_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)$/;"	v
+services_	muduo/net/protorpc/RpcChannel.h	/^  const std::map<std::string, ::google::protobuf::Service*>* services_;$/;"	m	class:muduo::net::RpcChannel
+services_	muduo/net/protorpc/RpcServer.h	/^  std::map<std::string, ::google::protobuf::Service*> services_;$/;"	m	class:muduo::net::RpcServer
+sessionCount_	examples/pingpong/client.cc	/^  int sessionCount_;$/;"	m	class:Client	file:
+sessions_	examples/memcached/server/MemcacheServer.h	/^  boost::unordered_map<string, SessionPtr> sessions_;$/;"	m	class:MemcacheServer
+sessions_	examples/pingpong/client.cc	/^  boost::ptr_vector<Session> sessions_;$/;"	m	class:Client	file:
+set	muduo/base/StringPiece.h	/^  void set(const char* buffer, int len) { ptr_ = buffer; length_ = len; }$/;"	f	class:muduo::StringPiece
+set	muduo/base/StringPiece.h	/^  void set(const char* str) {$/;"	f	class:muduo::StringPiece
+set	muduo/base/StringPiece.h	/^  void set(const void* buffer, int len) {$/;"	f	class:muduo::StringPiece
+set	muduo/base/ThreadLocalSingleton.h	/^    void set(T* newObj)$/;"	f	class:muduo::ThreadLocalSingleton::Deleter
+setBody	muduo/net/http/HttpResponse.h	/^  void setBody(const string& body)$/;"	f	class:muduo::net::HttpResponse
+setCas	examples/memcached/server/Item.h	/^  void setCas(uint64_t casArg)$/;"	f	class:Item
+setChannel	examples/curl/Curl.cc	/^Channel* Request::setChannel(int fd)$/;"	f	class:Request
+setCloseCallback	muduo/net/Channel.h	/^  void setCloseCallback(EventCallback&& cb)$/;"	f	class:muduo::net::Channel
+setCloseCallback	muduo/net/Channel.h	/^  void setCloseCallback(const EventCallback& cb)$/;"	f	class:muduo::net::Channel
+setCloseCallback	muduo/net/TcpConnection.h	/^  void setCloseCallback(const CloseCallback& cb)$/;"	f	class:muduo::net::TcpConnection
+setCloseConnection	muduo/net/http/HttpResponse.h	/^  void setCloseConnection(bool on)$/;"	f	class:muduo::net::HttpResponse
+setConnection	muduo/net/protorpc/RpcChannel.h	/^  void setConnection(const TcpConnectionPtr& conn)$/;"	f	class:muduo::net::RpcChannel
+setConnectionCallback	examples/hub/pubsub.h	/^  void setConnectionCallback(const ConnectionCallback& cb)$/;"	f	class:pubsub::PubSubClient
+setConnectionCallback	muduo/net/TcpClient.h	/^  void setConnectionCallback(ConnectionCallback&& cb)$/;"	f	class:muduo::net::TcpClient
+setConnectionCallback	muduo/net/TcpClient.h	/^  void setConnectionCallback(const ConnectionCallback& cb)$/;"	f	class:muduo::net::TcpClient
+setConnectionCallback	muduo/net/TcpConnection.h	/^  void setConnectionCallback(const ConnectionCallback& cb)$/;"	f	class:muduo::net::TcpConnection
+setConnectionCallback	muduo/net/TcpServer.h	/^  void setConnectionCallback(const ConnectionCallback& cb)$/;"	f	class:muduo::net::TcpServer
+setContentType	muduo/net/http/HttpResponse.h	/^  void setContentType(const string& contentType)$/;"	f	class:muduo::net::HttpResponse
+setContext	muduo/net/TcpConnection.h	/^  void setContext(const boost::any& context)$/;"	f	class:muduo::net::TcpConnection
+setCookie	muduo/base/LogStream.h	/^  void setCookie(void (*cookie)()) { cookie_ = cookie; }$/;"	f	class:muduo::detail::FixedBuffer
+setDataCallback	examples/curl/Curl.h	/^  void setDataCallback(const DataCallback& cb)$/;"	f	class:curl::Request
+setDoneCallback	examples/curl/Curl.h	/^  void setDoneCallback(const DoneCallback& cb)$/;"	f	class:curl::Request
+setErrorCallback	muduo/net/Channel.h	/^  void setErrorCallback(EventCallback&& cb)$/;"	f	class:muduo::net::Channel
+setErrorCallback	muduo/net/Channel.h	/^  void setErrorCallback(const EventCallback& cb)$/;"	f	class:muduo::net::Channel
+setFlush	muduo/base/Logging.cc	/^void Logger::setFlush(FlushFunc flush)$/;"	f	class:Logger
+setHeaderCallback	examples/curl/Curl.h	/^  void setHeaderCallback(const DataCallback& cb)$/;"	f	class:curl::Request
+setHighWaterMarkCallback	muduo/net/TcpConnection.h	/^  void setHighWaterMarkCallback(const HighWaterMarkCallback& cb, size_t highWaterMark)$/;"	f	class:muduo::net::TcpConnection
+setHttpCallback	muduo/net/http/HttpServer.h	/^  void setHttpCallback(const HttpCallback& cb)$/;"	f	class:muduo::net::HttpServer
+setId	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/MockClient.java	/^    public void setId(int connId) {$/;"	m	class:MockClient
+setKeepAlive	muduo/net/Socket.cc	/^void Socket::setKeepAlive(bool on)$/;"	f	class:Socket
+setLogLevel	muduo/base/Logging.cc	/^void Logger::setLogLevel(Logger::LogLevel level)$/;"	f	class:Logger
+setMaxQueueSize	muduo/base/ThreadPool.h	/^  void setMaxQueueSize(int maxSize) { maxQueueSize_ = maxSize; }$/;"	f	class:muduo::ThreadPool
+setMessageCallback	muduo/net/TcpClient.h	/^  void setMessageCallback(MessageCallback&& cb)$/;"	f	class:muduo::net::TcpClient
+setMessageCallback	muduo/net/TcpClient.h	/^  void setMessageCallback(const MessageCallback& cb)$/;"	f	class:muduo::net::TcpClient
+setMessageCallback	muduo/net/TcpConnection.h	/^  void setMessageCallback(const MessageCallback& cb)$/;"	f	class:muduo::net::TcpConnection
+setMessageCallback	muduo/net/TcpServer.h	/^  void setMessageCallback(const MessageCallback& cb)$/;"	f	class:muduo::net::TcpServer
+setMethod	muduo/net/http/HttpRequest.h	/^  bool setMethod(const char* start, const char* end)$/;"	f	class:muduo::net::HttpRequest
+setName	muduo/base/tests/SingletonThreadLocal_test.cc	/^  void setName(const std::string& n) { name_ = n; }$/;"	f	class:Test
+setName	muduo/base/tests/Singleton_test.cc	/^  void setName(const muduo::string& n) { name_ = n; }$/;"	f	class:Test
+setName	muduo/base/tests/ThreadLocalSingleton_test.cc	/^  void setName(const std::string& n) { name_ = n; }$/;"	f	class:Test
+setName	muduo/base/tests/ThreadLocal_test.cc	/^  void setName(const std::string& n) { name_ = n; }$/;"	f	class:Test
+setNewConnectionCallback	muduo/net/Acceptor.h	/^  void setNewConnectionCallback(const NewConnectionCallback& cb)$/;"	f	class:muduo::net::Acceptor
+setNewConnectionCallback	muduo/net/Connector.h	/^  void setNewConnectionCallback(const NewConnectionCallback& cb)$/;"	f	class:muduo::net::Connector
+setNonBlockAndCloseOnExec	muduo/net/SocketsOps.cc	/^void setNonBlockAndCloseOnExec(int sockfd)$/;"	f	namespace:__anon1
+setOutput	muduo/base/Logging.cc	/^void Logger::setOutput(OutputFunc out)$/;"	f	class:Logger
+setOwner	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/TestCase.java	/^    public void setOwner(MultiplexerTest god) {$/;"	m	class:TestCase
+setPath	muduo/net/http/HttpRequest.h	/^  void setPath(const char* start, const char* end)$/;"	f	class:muduo::net::HttpRequest
+setQuery	muduo/net/http/HttpRequest.h	/^  void setQuery(const char* start, const char* end)$/;"	f	class:muduo::net::HttpRequest
+setRange	examples/curl/Curl.cc	/^void Request::setRange(muduo::StringPiece range)$/;"	f	class:Request
+setReadCallback	muduo/net/Channel.h	/^  void setReadCallback(ReadEventCallback&& cb)$/;"	f	class:muduo::net::Channel
+setReadCallback	muduo/net/Channel.h	/^  void setReadCallback(const ReadEventCallback& cb)$/;"	f	class:muduo::net::Channel
+setReceiveTime	muduo/net/http/HttpRequest.h	/^  void setReceiveTime(Timestamp t)$/;"	f	class:muduo::net::HttpRequest
+setReuseAddr	muduo/net/Socket.cc	/^void Socket::setReuseAddr(bool on)$/;"	f	class:Socket
+setReusePort	muduo/net/Socket.cc	/^void Socket::setReusePort(bool on)$/;"	f	class:Socket
+setServices	muduo/net/protorpc/RpcChannel.h	/^  void setServices(const std::map<std::string, ::google::protobuf::Service*>* services)$/;"	f	class:muduo::net::RpcChannel
+setSockAddrInet	muduo/net/InetAddress.h	/^  void setSockAddrInet(const struct sockaddr_in& addr) { addr_ = addr; }$/;"	f	class:muduo::net::InetAddress
+setState	muduo/net/Connector.h	/^  void setState(States s) { state_ = s; }$/;"	f	class:muduo::net::Connector
+setState	muduo/net/TcpConnection.h	/^  void setState(StateE s) { state_ = s; }$/;"	f	class:muduo::net::TcpConnection
+setStatusCode	muduo/net/http/HttpResponse.h	/^  void setStatusCode(HttpStatusCode code)$/;"	f	class:muduo::net::HttpResponse
+setStatusMessage	muduo/net/http/HttpResponse.h	/^  void setStatusMessage(const string& message)$/;"	f	class:muduo::net::HttpResponse
+setTcpNoDelay	muduo/net/Socket.cc	/^void Socket::setTcpNoDelay(bool on)$/;"	f	class:Socket
+setTcpNoDelay	muduo/net/TcpConnection.cc	/^void TcpConnection::setTcpNoDelay(bool on)$/;"	f	class:TcpConnection
+setThreadInitCallback	muduo/net/TcpServer.h	/^  void setThreadInitCallback(const ThreadInitCallback& cb)$/;"	f	class:muduo::net::TcpServer
+setThreadNum	examples/asio/chat/server_threaded.cc	/^  void setThreadNum(int numThreads)$/;"	f	class:ChatServer
+setThreadNum	examples/asio/chat/server_threaded_efficient.cc	/^  void setThreadNum(int numThreads)$/;"	f	class:ChatServer
+setThreadNum	examples/asio/chat/server_threaded_highperformance.cc	/^  void setThreadNum(int numThreads)$/;"	f	class:ChatServer
+setThreadNum	examples/memcached/server/MemcacheServer.h	/^  void setThreadNum(int threads) { server_.setThreadNum(threads); }$/;"	f	class:MemcacheServer
+setThreadNum	muduo/net/EventLoopThreadPool.h	/^  void setThreadNum(int numThreads) { numThreads_ = numThreads; }$/;"	f	class:muduo::net::EventLoopThreadPool
+setThreadNum	muduo/net/TcpServer.cc	/^void TcpServer::setThreadNum(int numThreads)$/;"	f	class:TcpServer
+setThreadNum	muduo/net/http/HttpServer.h	/^  void setThreadNum(int numThreads)$/;"	f	class:muduo::net::HttpServer
+setThreadNum	muduo/net/protorpc/RpcServer.h	/^  void setThreadNum(int numThreads)$/;"	f	class:muduo::net::RpcServer
+setVersion	muduo/net/http/HttpRequest.h	/^  void setVersion(Version v)$/;"	f	class:muduo::net::HttpRequest
+setWriteCallback	muduo/net/Channel.h	/^  void setWriteCallback(EventCallback&& cb)$/;"	f	class:muduo::net::Channel
+setWriteCallback	muduo/net/Channel.h	/^  void setWriteCallback(const EventCallback& cb)$/;"	f	class:muduo::net::Channel
+setWriteCompleteCallback	muduo/net/TcpClient.h	/^  void setWriteCompleteCallback(WriteCompleteCallback&& cb)$/;"	f	class:muduo::net::TcpClient
+setWriteCompleteCallback	muduo/net/TcpClient.h	/^  void setWriteCompleteCallback(const WriteCompleteCallback& cb)$/;"	f	class:muduo::net::TcpClient
+setWriteCompleteCallback	muduo/net/TcpConnection.h	/^  void setWriteCompleteCallback(const WriteCompleteCallback& cb)$/;"	f	class:muduo::net::TcpConnection
+setWriteCompleteCallback	muduo/net/TcpServer.h	/^  void setWriteCompleteCallback(const WriteCompleteCallback& cb)$/;"	f	class:muduo::net::TcpServer
+set_index	muduo/net/Channel.h	/^  void set_index(int idx) { index_ = idx; }$/;"	f	class:muduo::net::Channel
+set_revents	muduo/net/Channel.h	/^  void set_revents(int revt) { revents_ = revt; } \/\/ used by pollers$/;"	f	class:muduo::net::Channel
+setopt	examples/curl/Curl.h	/^  int setopt(OPT opt, const char* p)$/;"	f	class:curl::Request
+setopt	examples/curl/Curl.h	/^  int setopt(OPT opt, long p)$/;"	f	class:curl::Request
+setopt	examples/curl/Curl.h	/^  int setopt(OPT opt, size_t (*p)(char *, size_t , size_t , void *))$/;"	f	class:curl::Request
+setopt	examples/curl/Curl.h	/^  int setopt(OPT opt, void* p)$/;"	f	class:curl::Request
+setup	examples/socks4a/tunnel.h	/^  void setup()$/;"	f	class:Tunnel
+shards_	examples/memcached/server/MemcacheServer.h	/^  boost::array<MapWithLock, kShards> shards_;$/;"	m	class:MemcacheServer
+shrink	muduo/net/Buffer.h	/^  void shrink(size_t reserve)$/;"	f	class:muduo::net::Buffer
+shutdown	muduo/net/TcpConnection.cc	/^void TcpConnection::shutdown()$/;"	f	class:TcpConnection
+shutdownInLoop	muduo/net/TcpConnection.cc	/^void TcpConnection::shutdownInLoop()$/;"	f	class:TcpConnection
+shutdownWrite	muduo/net/Socket.cc	/^void Socket::shutdownWrite()$/;"	f	class:Socket
+shutdownWrite	muduo/net/SocketsOps.cc	/^void sockets::shutdownWrite(int sockfd)$/;"	f	class:sockets
+size	examples/sudoku/sudoku.cc	/^    int size;$/;"	m	struct:Node	file:
+size	examples/wordcount/slowsink.py	/^		size = len(data)$/;"	v
+size	muduo/base/BlockingQueue.h	/^  size_t size() const$/;"	f	class:muduo::BlockingQueue
+size	muduo/base/BoundedBlockingQueue.h	/^  size_t size() const$/;"	f	class:muduo::BoundedBlockingQueue
+size	muduo/base/StringPiece.h	/^  int size() const { return length_; }$/;"	f	class:muduo::StringPiece
+size_	muduo/base/Logging.h	/^    int size_;$/;"	m	class:muduo::Logger::SourceFile
+sleep	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/MultiplexerTest.java	/^    public void sleep(int millis) {$/;"	m	class:MultiplexerTest
+sleepUsec	muduo/base/Thread.cc	/^void CurrentThread::sleepUsec(int64_t usec)$/;"	f	class:CurrentThread
+sockaddr_cast	muduo/net/SocketsOps.cc	/^SA* sockaddr_cast(struct sockaddr_in* addr)$/;"	f	namespace:__anon1
+sockaddr_cast	muduo/net/SocketsOps.cc	/^const SA* sockaddr_cast(const struct sockaddr_in* addr)$/;"	f	namespace:__anon1
+socket	examples/wordcount/slowsink.py	/^import os, socket, sys, time$/;"	i
+socketCallback	examples/curl/Curl.cc	/^int Curl::socketCallback(CURL* c, int fd, int what, void* userp, void* socketp)$/;"	f	class:Curl
+socket_	muduo/net/TcpConnection.h	/^  boost::scoped_ptr<Socket> socket_;$/;"	m	class:muduo::net::TcpConnection
+sockets	muduo/net/Endian.h	/^namespace sockets$/;"	n	namespace:muduo::net
+sockets	muduo/net/SocketsOps.h	/^namespace sockets$/;"	n	namespace:muduo::net
+sockfd_	muduo/net/Socket.h	/^  const int sockfd_;$/;"	m	class:muduo::net::Socket
+socksAddr_	examples/multiplexer/demux.cc	/^  const InetAddress socksAddr_;$/;"	m	class:DemuxServer	file:
+socksConns_	examples/multiplexer/demux.cc	/^  std::map<int, Entry> socksConns_;$/;"	m	class:DemuxServer	file:
+socksIp	examples/multiplexer/demux.cc	/^const char* socksIp = "127.0.0.1";$/;"	v
+solve	examples/sudoku/server_threadpool.cc	/^  static void solve(const TcpConnectionPtr& conn,$/;"	f	class:SudokuServer	file:
+solve	examples/sudoku/sudoku.cc	/^    bool solve()$/;"	f	class:SudokuSolver
+solveSudoku	examples/sudoku/sudoku.cc	/^string solveSudoku(const StringPiece& puzzle)$/;"	f
+solved	examples/protobuf/rpc/client.cc	/^  void solved(sudoku::SudokuResponse* resp)$/;"	f	class:RpcClient	file:
+source	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/DataEvent.java	/^    public final EventSource source;$/;"	f	class:DataEvent
+split	muduo/net/inspect/Inspector.cc	/^std::vector<string> split(const string& str)$/;"	f	namespace:__anon2
+stackTrace	muduo/base/Exception.cc	/^const char* Exception::stackTrace() const throw()$/;"	f	class:Exception
+stack_	examples/sudoku/sudoku.cc	/^    std::vector<Node*> stack_;$/;"	m	class:SudokuSolver	file:
+stack_	muduo/base/Exception.h	/^  string stack_;$/;"	m	class:muduo::Exception
+start	examples/asio/chat/server.cc	/^  void start()$/;"	f	class:ChatServer
+start	examples/asio/chat/server_threaded.cc	/^  void start()$/;"	f	class:ChatServer
+start	examples/asio/chat/server_threaded_efficient.cc	/^  void start()$/;"	f	class:ChatServer
+start	examples/asio/chat/server_threaded_highperformance.cc	/^  void start()$/;"	f	class:ChatServer
+start	examples/hub/hub.cc	/^  void start()$/;"	f	class:pubsub::PubSubServer
+start	examples/hub/pubsub.cc	/^void PubSubClient::start()$/;"	f	class:PubSubClient
+start	examples/idleconnection/echo.cc	/^void EchoServer::start()$/;"	f	class:EchoServer
+start	examples/idleconnection/sortedlist.cc	/^  void start()$/;"	f	class:EchoServer
+start	examples/maxconnection/echo.cc	/^void EchoServer::start()$/;"	f	class:EchoServer
+start	examples/memcached/server/MemcacheServer.cc	/^void MemcacheServer::start()$/;"	f	class:MemcacheServer
+start	examples/multiplexer/demux.cc	/^  void start()$/;"	f	class:DemuxServer
+start	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/MockBackendServer.java	/^    public void start() {$/;"	m	class:MockBackendServer
+start	examples/multiplexer/multiplexer.cc	/^  void start()$/;"	f	class:MultiplexServer
+start	examples/multiplexer/multiplexer_simple.cc	/^  void start()$/;"	f	class:MultiplexServer
+start	examples/netty/discard/server.cc	/^  void start()$/;"	f	class:DiscardServer
+start	examples/netty/echo/server.cc	/^  void start()$/;"	f	class:EchoServer
+start	examples/pingpong/client.cc	/^  void start()$/;"	f	class:Session
+start	examples/protobuf/codec/server.cc	/^  void start()$/;"	f	class:QueryServer
+start	examples/simple/chargen/chargen.cc	/^void ChargenServer::start()$/;"	f	class:ChargenServer
+start	examples/simple/daytime/daytime.cc	/^void DaytimeServer::start()$/;"	f	class:DaytimeServer
+start	examples/simple/discard/discard.cc	/^void DiscardServer::start()$/;"	f	class:DiscardServer
+start	examples/simple/echo/echo.cc	/^void EchoServer::start()$/;"	f	class:EchoServer
+start	examples/simple/time/time.cc	/^void TimeServer::start()$/;"	f	class:TimeServer
+start	examples/sudoku/server_basic.cc	/^  void start()$/;"	f	class:SudokuServer
+start	examples/sudoku/server_multiloop.cc	/^  void start()$/;"	f	class:SudokuServer
+start	examples/sudoku/server_threadpool.cc	/^  void start()$/;"	f	class:SudokuServer
+start	examples/wordcount/receiver.cc	/^  void start(int senders)$/;"	f	class:WordCountReceiver
+start	examples/wordcount/slowsink.py	/^start = time.time()$/;"	v
+start	muduo/base/AsyncLogging.h	/^  void start()$/;"	f	class:muduo::AsyncLogging
+start	muduo/base/Thread.cc	/^void Thread::start()$/;"	f	class:Thread
+start	muduo/base/ThreadPool.cc	/^void ThreadPool::start(int numThreads)$/;"	f	class:ThreadPool
+start	muduo/net/Connector.cc	/^void Connector::start()$/;"	f	class:Connector
+start	muduo/net/EventLoopThreadPool.cc	/^void EventLoopThreadPool::start(const ThreadInitCallback& cb)$/;"	f	class:EventLoopThreadPool
+start	muduo/net/TcpServer.cc	/^void TcpServer::start()$/;"	f	class:TcpServer
+start	muduo/net/http/HttpServer.cc	/^void HttpServer::start()$/;"	f	class:HttpServer
+start	muduo/net/inspect/Inspector.cc	/^void Inspector::start()$/;"	f	class:Inspector
+start	muduo/net/protorpc/RpcServer.cc	/^void RpcServer::start()$/;"	f	class:RpcServer
+start	muduo/net/tests/EchoServer_unittest.cc	/^  void start()$/;"	f	class:EchoServer
+startInLoop	muduo/net/Connector.cc	/^void Connector::startInLoop()$/;"	f	class:Connector
+startLoop	muduo/net/EventLoopThread.cc	/^EventLoop* EventLoopThread::startLoop()$/;"	f	class:EventLoopThread
+startOfPeriod_	muduo/base/LogFile.h	/^  time_t startOfPeriod_;$/;"	m	class:muduo::LogFile
+startThread	muduo/base/Thread.cc	/^void* startThread(void* obj)$/;"	f	namespace:muduo::detail
+startTime	examples/memcached/server/MemcacheServer.h	/^  time_t startTime() const { return startTime_; }$/;"	f	class:MemcacheServer
+startTime	muduo/base/ProcessInfo.cc	/^Timestamp ProcessInfo::startTime()$/;"	f	class:ProcessInfo
+startTime_	examples/memcached/server/MemcacheServer.h	/^  const time_t startTime_;$/;"	m	class:MemcacheServer
+startTime_	examples/multiplexer/multiplexer.cc	/^  Timestamp startTime_;$/;"	m	class:MultiplexServer	file:
+startTime_	examples/netty/discard/server.cc	/^  Timestamp startTime_;$/;"	m	class:DiscardServer	file:
+startTime_	examples/netty/echo/server.cc	/^  Timestamp startTime_;$/;"	m	class:EchoServer	file:
+startTime_	examples/simple/chargen/chargen.h	/^  muduo::Timestamp startTime_;$/;"	m	class:ChargenServer
+startTime_	examples/sudoku/server_basic.cc	/^  Timestamp startTime_;$/;"	m	class:SudokuServer	file:
+startTime_	examples/sudoku/server_multiloop.cc	/^  Timestamp startTime_;$/;"	m	class:SudokuServer	file:
+startTime_	examples/sudoku/server_threadpool.cc	/^  Timestamp startTime_;$/;"	m	class:SudokuServer	file:
+startWith	examples/curl/download.cc	/^bool startWith(const string& str, const char (&prefix)[N])$/;"	f
+start_	examples/sudoku/client.cc	/^  Timestamp start_;$/;"	m	class:SudokuClient	file:
+started	muduo/base/Thread.h	/^  bool started() const { return started_; }$/;"	f	class:muduo::Thread
+started_	muduo/base/Thread.h	/^  bool       started_;$/;"	m	class:muduo::Thread
+started_	muduo/net/EventLoopThreadPool.h	/^  bool started_;$/;"	m	class:muduo::net::EventLoopThreadPool
+started_	muduo/net/TcpServer.h	/^  bool started_;$/;"	m	class:muduo::net::TcpServer
+starts_with	muduo/base/StringPiece.h	/^  bool starts_with(const StringPiece& x) const {$/;"	f	class:muduo::StringPiece
+state_	examples/memcached/server/Session.h	/^  State state_;$/;"	m	class:Session
+state_	muduo/net/Connector.h	/^  States state_;  \/\/ FIXME: use atomic variable$/;"	m	class:muduo::net::Connector
+state_	muduo/net/TcpConnection.h	/^  StateE state_;  \/\/ FIXME: use atomic variable$/;"	m	class:muduo::net::TcpConnection
+state_	muduo/net/http/HttpContext.h	/^  HttpRequestParseState state_;$/;"	m	class:muduo::net::HttpContext
+staticCheck	muduo/base/LogStream.cc	/^void LogStream::staticCheck()$/;"	f	class:LogStream
+statistic	examples/asio/chat/loadtest.cc	/^void statistic(const boost::ptr_vector<ChatClient>& clients)$/;"	f
+stats_	examples/memcached/server/MemcacheServer.h	/^  boost::scoped_ptr<Stats> stats_;$/;"	m	class:MemcacheServer
+statusCode_	muduo/net/http/HttpResponse.h	/^  HttpStatusCode statusCode_;$/;"	m	class:muduo::net::HttpResponse
+statusMessage_	muduo/net/http/HttpResponse.h	/^  string statusMessage_;$/;"	m	class:muduo::net::HttpResponse
+stdin_	examples/fastcgi/fastcgi.h	/^  muduo::net::Buffer stdin_;$/;"	m	class:FastCgiCodec
+stop	examples/hub/pubsub.cc	/^void PubSubClient::stop()$/;"	f	class:PubSubClient
+stop	examples/memcached/server/MemcacheServer.cc	/^void MemcacheServer::stop()$/;"	f	class:MemcacheServer
+stop	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/MockBackendServer.java	/^    public void stop() {$/;"	m	class:MockBackendServer
+stop	examples/pingpong/client.cc	/^  void stop()$/;"	f	class:Session
+stop	muduo/base/AsyncLogging.h	/^  void stop()$/;"	f	class:muduo::AsyncLogging
+stop	muduo/base/ThreadPool.cc	/^void ThreadPool::stop()$/;"	f	class:ThreadPool
+stop	muduo/net/Connector.cc	/^void Connector::stop()$/;"	f	class:Connector
+stop	muduo/net/TcpClient.cc	/^void TcpClient::stop()$/;"	f	class:TcpClient
+stopInLoop	muduo/net/Connector.cc	/^void Connector::stopInLoop()$/;"	f	class:Connector
+storeItem	examples/memcached/server/MemcacheServer.cc	/^bool MemcacheServer::storeItem(const ItemPtr& item, const Item::UpdatePolicy policy, bool* exists)$/;"	f	class:MemcacheServer
+str_	muduo/base/Logging.cc	/^  const char* str_;$/;"	m	class:muduo::T	file:
+stream	muduo/base/Logging.h	/^  LogStream& stream() { return impl_.stream_; }$/;"	f	class:muduo::Logger
+stream_	muduo/base/Logging.h	/^  LogStream stream_;$/;"	m	class:muduo::Logger::Impl
+strerror_tl	muduo/base/Logging.cc	/^const char* strerror_tl(int savedErrno)$/;"	f	namespace:muduo
+stringPrintf	muduo/net/inspect/ProcessInspector.cc	/^int stringPrintf(string* out, const char* fmt, ...)$/;"	f
+stub_	examples/protobuf/resolver/client.cc	/^  resolver::ResolverService::Stub stub_;$/;"	m	class:RpcClient	file:
+stub_	examples/protobuf/rpc/client.cc	/^  sudoku::SudokuService::Stub stub_;$/;"	m	class:RpcClient	file:
+stub_	examples/protobuf/rpcbench/client.cc	/^  echo::EchoService::Stub stub_;$/;"	m	class:RpcClient	file:
+subscribe	examples/hub/pubsub.cc	/^bool PubSubClient::subscribe(const string& topic, const SubscribeCallback& cb)$/;"	f	class:PubSubClient
+subscribeCallback_	examples/hub/pubsub.h	/^  SubscribeCallback subscribeCallback_;$/;"	m	class:pubsub::PubSubClient
+subscription	examples/hub/sub.cc	/^void subscription(const string& topic, const string& content, Timestamp)$/;"	f
+sudoku	examples/protobuf/rpc/server.cc	/^namespace sudoku$/;"	n	file:
+swap	muduo/base/Date.h	/^  void swap(Date& that)$/;"	f	class:muduo::Date
+swap	muduo/base/Timestamp.h	/^  void swap(Timestamp& that)$/;"	f	class:muduo::Timestamp
+swap	muduo/net/Buffer.h	/^  void swap(Buffer& rhs)$/;"	f	class:muduo::net::Buffer
+swap	muduo/net/http/HttpRequest.h	/^  void swap(HttpRequest& that)$/;"	f	class:muduo::net::HttpRequest
+sys	examples/wordcount/slowsink.py	/^import os, socket, sys, time$/;"	i
+t_cachedTid	muduo/base/Thread.cc	/^  __thread int t_cachedTid = 0;$/;"	m	namespace:muduo::CurrentThread	file:
+t_errnobuf	muduo/base/Logging.cc	/^__thread char t_errnobuf[512];$/;"	m	namespace:muduo	file:
+t_lastSecond	muduo/base/Logging.cc	/^__thread time_t t_lastSecond;$/;"	m	namespace:muduo	file:
+t_loopInThisThread	muduo/net/EventLoop.cc	/^__thread EventLoop* t_loopInThisThread = 0;$/;"	m	namespace:__anon4	file:
+t_numOpenedFiles	muduo/base/ProcessInfo.cc	/^__thread int t_numOpenedFiles = 0;$/;"	m	namespace:muduo::detail	file:
+t_pids	muduo/base/ProcessInfo.cc	/^__thread std::vector<pid_t>* t_pids = NULL;$/;"	m	namespace:muduo::detail	file:
+t_threadName	muduo/base/Thread.cc	/^  __thread const char* t_threadName = "unknown";$/;"	m	namespace:muduo::CurrentThread	file:
+t_tidString	muduo/base/Thread.cc	/^  __thread char t_tidString[32];$/;"	m	namespace:muduo::CurrentThread	file:
+t_time	muduo/base/Logging.cc	/^__thread char t_time[32];$/;"	m	namespace:muduo	file:
+t_value_	muduo/base/ThreadLocalSingleton.h	/^  static __thread T* t_value_;$/;"	m	class:muduo::ThreadLocalSingleton
+t_value_	muduo/base/ThreadLocalSingleton.h	/^__thread T* ThreadLocalSingleton<T>::t_value_ = 0;$/;"	m	class:muduo::ThreadLocalSingleton
+take	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/EventQueue.java	/^    public Event take() {$/;"	m	class:EventQueue
+take	muduo/base/BlockingQueue.h	/^  T take()$/;"	f	class:muduo::BlockingQueue
+take	muduo/base/BoundedBlockingQueue.h	/^  T take()$/;"	f	class:muduo::BoundedBlockingQueue
+take	muduo/base/ThreadPool.cc	/^ThreadPool::Task ThreadPool::take()$/;"	f	class:ThreadPool
+taskDirFilter	muduo/base/ProcessInfo.cc	/^int taskDirFilter(const struct dirent* d)$/;"	f	namespace:muduo::detail
+tcpport	examples/memcached/server/MemcacheServer.h	/^    uint16_t tcpport;$/;"	m	struct:MemcacheServer::Options
+teardown	examples/socks4a/tunnel.h	/^  void teardown()$/;"	f	class:Tunnel
+test	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/TestCase.java	/^    public void test() {$/;"	m	class:TestCase
+test	muduo/base/tests/Exception_test.cc	/^  void test()$/;"	f	class:Bar
+test	muduo/base/tests/ThreadPool_test.cc	/^void test(int maxSize)$/;"	f
+test	muduo/base/tests/TimeZone_unittest.cc	/^void test(const TimeZone& tz, TestCase tc)$/;"	f
+testAnswer	examples/protobuf/codec/codec_test.cc	/^void testAnswer()$/;"	f
+testBadBuffer	examples/protobuf/codec/codec_test.cc	/^void testBadBuffer()$/;"	f
+testCases	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/MultiplexerTest.java	/^    private ArrayList<TestCase> testCases;$/;"	f	class:MultiplexerTest	file:
+testEmpty	examples/protobuf/codec/codec_test.cc	/^void testEmpty()$/;"	f
+testHash	examples/idleconnection/main.cc	/^void testHash()$/;"	f
+testHongKong	muduo/base/tests/TimeZone_unittest.cc	/^void testHongKong()$/;"	f
+testLondon	muduo/base/tests/TimeZone_unittest.cc	/^void testLondon()$/;"	f
+testNewYork	muduo/base/tests/TimeZone_unittest.cc	/^void testNewYork()$/;"	f
+testObj1	muduo/base/tests/ThreadLocal_test.cc	/^muduo::ThreadLocal<Test> testObj1;$/;"	v
+testObj2	muduo/base/tests/ThreadLocal_test.cc	/^muduo::ThreadLocal<Test> testObj2;$/;"	v
+testOnMessage	examples/protobuf/codec/codec_test.cc	/^void testOnMessage()$/;"	f
+testQuery	examples/protobuf/codec/codec_test.cc	/^void testQuery()$/;"	f
+testSydney	muduo/base/tests/TimeZone_unittest.cc	/^void testSydney()$/;"	f
+testUtc	muduo/base/tests/TimeZone_unittest.cc	/^void testUtc()$/;"	f
+test_down_pointer_cast	examples/protobuf/codec/dispatcher_test.cc	/^void test_down_pointer_cast()$/;"	f
+threadFunc	muduo/base/AsyncLogging.cc	/^void AsyncLogging::threadFunc()$/;"	f	class:AsyncLogging
+threadFunc	muduo/base/tests/BlockingQueue_bench.cc	/^  void threadFunc()$/;"	f	class:Bench	file:
+threadFunc	muduo/base/tests/BlockingQueue_test.cc	/^  void threadFunc()$/;"	f	class:Test	file:
+threadFunc	muduo/base/tests/BoundedBlockingQueue_test.cc	/^  void threadFunc()$/;"	f	class:Test	file:
+threadFunc	muduo/base/tests/Mutex_test.cc	/^void threadFunc()$/;"	f
+threadFunc	muduo/base/tests/SingletonThreadLocal_test.cc	/^void threadFunc(const char* changeTo)$/;"	f
+threadFunc	muduo/base/tests/Singleton_test.cc	/^void threadFunc()$/;"	f
+threadFunc	muduo/base/tests/ThreadLocalSingleton_test.cc	/^void threadFunc(const char* changeTo)$/;"	f
+threadFunc	muduo/base/tests/ThreadLocal_test.cc	/^void threadFunc()$/;"	f
+threadFunc	muduo/base/tests/Thread_bench.cc	/^void threadFunc()$/;"	f
+threadFunc	muduo/base/tests/Thread_test.cc	/^void threadFunc()$/;"	f
+threadFunc	muduo/net/EventLoopThread.cc	/^void EventLoopThread::threadFunc()$/;"	f	class:EventLoopThread
+threadFunc	muduo/net/tests/EventLoop_unittest.cc	/^void threadFunc()$/;"	f
+threadFunc2	muduo/base/tests/Thread_bench.cc	/^void threadFunc2(muduo::Timestamp start)$/;"	f
+threadFunc2	muduo/base/tests/Thread_test.cc	/^void threadFunc2(int x)$/;"	f
+threadFunc3	muduo/base/tests/Thread_test.cc	/^void threadFunc3()$/;"	f
+threadId_	muduo/net/EventLoop.h	/^  const pid_t threadId_;$/;"	m	class:muduo::net::EventLoop
+threadInit	examples/asio/chat/server_threaded_highperformance.cc	/^  void threadInit(EventLoop* loop)$/;"	f	class:ChatServer	file:
+threadInitCallback_	muduo/net/TcpServer.h	/^  ThreadInitCallback threadInitCallback_;$/;"	m	class:muduo::net::TcpServer
+threadPool_	examples/pingpong/client.cc	/^  EventLoopThreadPool threadPool_;$/;"	m	class:Client	file:
+threadPool_	examples/sudoku/server_threadpool.cc	/^  ThreadPool threadPool_;$/;"	m	class:SudokuServer	file:
+threadPool_	muduo/net/TcpServer.h	/^  boost::scoped_ptr<EventLoopThreadPool> threadPool_;$/;"	m	class:muduo::net::TcpServer
+thread_	muduo/base/AsyncLogging.h	/^  muduo::Thread thread_;$/;"	m	class:muduo::AsyncLogging
+thread_	muduo/net/EventLoopThread.h	/^  Thread thread_;$/;"	m	class:muduo::net::EventLoopThread
+threads	examples/memcached/server/MemcacheServer.h	/^    int threads;$/;"	m	struct:MemcacheServer::Options
+threads	muduo/base/ProcessInfo.cc	/^std::vector<pid_t> ProcessInfo::threads()$/;"	f	class:ProcessInfo
+threads	muduo/net/inspect/ProcessInspector.cc	/^string ProcessInspector::threads(HttpRequest::Method, const Inspector::ArgList&)$/;"	f	class:ProcessInspector
+threads_	muduo/base/ThreadPool.h	/^  boost::ptr_vector<muduo::Thread> threads_;$/;"	m	class:muduo::ThreadPool
+threads_	muduo/base/tests/BlockingQueue_bench.cc	/^  boost::ptr_vector<muduo::Thread> threads_;$/;"	m	class:Bench	file:
+threads_	muduo/base/tests/BlockingQueue_test.cc	/^  boost::ptr_vector<muduo::Thread> threads_;$/;"	m	class:Test	file:
+threads_	muduo/base/tests/BoundedBlockingQueue_test.cc	/^  boost::ptr_vector<muduo::Thread> threads_;$/;"	m	class:Test	file:
+threads_	muduo/net/EventLoopThreadPool.h	/^  boost::ptr_vector<EventLoopThread> threads_;$/;"	m	class:muduo::net::EventLoopThreadPool
+throttle	examples/wordcount/hasher.cc	/^  void throttle()$/;"	f	class:SendThrottler	file:
+tid	muduo/base/CurrentThread.h	/^  inline int tid()$/;"	f	namespace:muduo::CurrentThread
+tid	muduo/base/Thread.h	/^  pid_t tid() const { return *tid_; }$/;"	f	class:muduo::Thread
+tidString	muduo/base/CurrentThread.h	/^  inline const char* tidString() \/\/ for logging$/;"	f	namespace:muduo::CurrentThread
+tid_	muduo/base/Thread.h	/^  boost::shared_ptr<pid_t> tid_;$/;"	m	class:muduo::Thread
+tie	muduo/net/Channel.cc	/^void Channel::tie(const boost::shared_ptr<void>& obj)$/;"	f	class:Channel
+tie_	muduo/net/Channel.h	/^  boost::weak_ptr<void> tie_;$/;"	m	class:muduo::net::Channel
+tied_	muduo/net/Channel.h	/^  bool tied_;$/;"	m	class:muduo::net::Channel
+time	examples/wordcount/slowsink.py	/^import os, socket, sys, time$/;"	i
+timeDifference	muduo/base/Timestamp.h	/^inline double timeDifference(Timestamp high, Timestamp low)$/;"	f	namespace:muduo
+timePublish	examples/hub/hub.cc	/^  void timePublish()$/;"	f	class:pubsub::PubSubServer	file:
+time_	muduo/base/Logging.h	/^  Timestamp time_;$/;"	m	class:muduo::Logger::Impl
+timeout	muduo/net/tests/TcpClient_reg1.cc	/^void timeout()$/;"	f
+timeout_	examples/pingpong/client.cc	/^  int timeout_;$/;"	m	class:Client	file:
+timer	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/MockClient.java	/^    private final Timer timer;$/;"	f	class:MockClient	file:
+timerActive_	examples/cdns/Resolver.h	/^  bool timerActive_;$/;"	m	class:cdns::Resolver
+timerCallback	examples/curl/Curl.cc	/^int Curl::timerCallback(CURLM* curlm, long ms, void* userp)$/;"	f	class:Curl
+timerQueue_	muduo/net/EventLoop.h	/^  boost::scoped_ptr<TimerQueue> timerQueue_;$/;"	m	class:muduo::net::EventLoop
+timer_	muduo/net/TimerId.h	/^  Timer* timer_;$/;"	m	class:muduo::net::TimerId
+timerfdChannel_	muduo/net/TimerQueue.h	/^  Channel timerfdChannel_;$/;"	m	class:muduo::net::TimerQueue
+timerfd_	muduo/net/TimerQueue.h	/^  const int timerfd_;$/;"	m	class:muduo::net::TimerQueue
+timers_	muduo/net/TimerQueue.h	/^  TimerList timers_;$/;"	m	class:muduo::net::TimerQueue
+toFormattedString	muduo/base/Timestamp.cc	/^string Timestamp::toFormattedString() const$/;"	f	class:Timestamp
+toHostPort	muduo/net/InetAddress.h	/^  string toHostPort() const __attribute__ ((deprecated))$/;"	f	class:muduo::net::InetAddress
+toIp	muduo/net/InetAddress.cc	/^string InetAddress::toIp() const$/;"	f	class:InetAddress
+toIp	muduo/net/SocketsOps.cc	/^void sockets::toIp(char* buf, size_t size,$/;"	f	class:sockets
+toIpPort	muduo/net/InetAddress.cc	/^string InetAddress::toIpPort() const$/;"	f	class:InetAddress
+toIpPort	muduo/net/SocketsOps.cc	/^void sockets::toIpPort(char* buf, size_t size,$/;"	f	class:sockets
+toIsoString	muduo/base/Date.cc	/^string Date::toIsoString() const$/;"	f	class:Date
+toLocalTime	muduo/base/TimeZone.cc	/^struct tm TimeZone::toLocalTime(time_t seconds) const$/;"	f	class:TimeZone
+toString	muduo/base/Timestamp.cc	/^string Timestamp::toString() const$/;"	f	class:Timestamp
+toStringPiece	muduo/net/Buffer.h	/^  StringPiece toStringPiece() const$/;"	f	class:muduo::net::Buffer
+toUtcTime	muduo/base/TimeZone.cc	/^struct tm TimeZone::toUtcTime(time_t secondsSinceEpoch, bool yday)$/;"	f	class:TimeZone
+topic_	examples/hub/hub.cc	/^  string topic_;$/;"	m	class:pubsub::Topic	file:
+topics_	examples/hub/hub.cc	/^  std::map<string, Topic> topics_;$/;"	m	class:pubsub::PubSubServer	file:
+total	examples/cdns/dns.cc	/^int total = 0;$/;"	v
+totalLen	examples/memcached/server/Item.h	/^  int totalLen() const { return keylen_ + valuelen_; }$/;"	f	class:Item
+total_	examples/protobuf/resolver/client.cc	/^  int total_;$/;"	m	class:RpcClient	file:
+total_size	examples/wordcount/slowsink.py	/^total_size = 0$/;"	v
+transferred_	examples/multiplexer/multiplexer.cc	/^  AtomicInt64 transferred_;$/;"	m	class:MultiplexServer	file:
+transferred_	examples/netty/discard/server.cc	/^  AtomicInt64 transferred_;$/;"	m	class:DiscardServer	file:
+transferred_	examples/netty/echo/server.cc	/^  AtomicInt64 transferred_;$/;"	m	class:EchoServer	file:
+transferred_	examples/simple/chargen/chargen.h	/^  int64_t transferred_;$/;"	m	class:ChargenServer
+transitions	muduo/base/TimeZone.cc	/^  vector<detail::Transition> transitions;$/;"	m	struct:TimeZone::Data	file:
+type	examples/fastcgi/fastcgi.cc	/^  uint8_t type;$/;"	m	struct:FastCgiCodec::RecordHeader	file:
+udpport	examples/memcached/server/MemcacheServer.h	/^    uint16_t udpport;$/;"	m	struct:MemcacheServer::Options
+uid	muduo/base/ProcessInfo.cc	/^uid_t ProcessInfo::uid()$/;"	f	class:ProcessInfo
+unassignHolder	muduo/base/Mutex.h	/^  void unassignHolder()$/;"	f	class:muduo::MutexLock
+uncover	examples/sudoku/sudoku.cc	/^    void uncover(Column* c)$/;"	f	class:SudokuSolver	file:
+unlock	muduo/base/Mutex.h	/^  void unlock()$/;"	f	class:muduo::MutexLock
+unsubscribe	examples/hub/pubsub.cc	/^void PubSubClient::unsubscribe(const string& topic)$/;"	f	class:PubSubClient
+unused	examples/fastcgi/fastcgi.cc	/^  uint8_t unused;$/;"	m	struct:FastCgiCodec::RecordHeader	file:
+up	examples/sudoku/sudoku.cc	/^    Node* up;$/;"	m	struct:Node	file:
+update	muduo/net/Channel.cc	/^void Channel::update()$/;"	f	class:Channel
+update	muduo/net/poller/EPollPoller.cc	/^void EPollPoller::update(int operation, Channel* channel)$/;"	f	class:EPollPoller
+updateChannel	muduo/net/EventLoop.cc	/^void EventLoop::updateChannel(Channel* channel)$/;"	f	class:EventLoop
+updateChannel	muduo/net/poller/EPollPoller.cc	/^void EPollPoller::updateChannel(Channel* channel)$/;"	f	class:EPollPoller
+updateChannel	muduo/net/poller/PollPoller.cc	/^void PollPoller::updateChannel(Channel* channel)$/;"	f	class:PollPoller
+uptime	muduo/net/inspect/ProcessInspector.cc	/^string uptime()$/;"	f
+url_	examples/curl/download.cc	/^  string url_;$/;"	m	class:Downloader	file:
+username	muduo/base/ProcessInfo.cc	/^string ProcessInfo::username()$/;"	f	class:ProcessInfo
+username_	muduo/net/inspect/ProcessInspector.cc	/^string ProcessInspector::username_ = ProcessInfo::username();$/;"	m	class:ProcessInspector	file:
+username_	muduo/net/inspect/ProcessInspector.h	/^  static string username_;$/;"	m	class:muduo::net::ProcessInspector
+users	examples/twisted/finger/finger06.cc	/^UserMap users;$/;"	v
+users	examples/twisted/finger/finger07.cc	/^UserMap users;$/;"	v
+valid	muduo/base/Date.h	/^  bool valid() const { return julianDayNumber_ > 0; }$/;"	f	class:muduo::Date
+valid	muduo/base/TimeZone.cc	/^  bool valid() const { return fp_; }$/;"	f	class:muduo::detail::File
+valid	muduo/base/TimeZone.h	/^  bool valid() const$/;"	f	class:muduo::TimeZone
+valid	muduo/base/Timestamp.h	/^  bool valid() const { return microSecondsSinceEpoch_ > 0; }$/;"	f	class:muduo::Timestamp
+value	examples/memcached/server/Item.h	/^  const char* value() const$/;"	f	class:Item
+value	muduo/base/ThreadLocal.h	/^  T& value()$/;"	f	class:muduo::ThreadLocal
+valueLength	examples/memcached/server/Item.h	/^  size_t valueLength() const$/;"	f	class:Item
+value_	examples/memcached/client/bench.cc	/^  string value_;$/;"	m	class:Client	file:
+value_	muduo/base/Atomic.h	/^  volatile T value_;$/;"	m	class:muduo::detail::AtomicIntegerT
+value_	muduo/base/Singleton.h	/^  static T*             value_;$/;"	m	class:muduo::Singleton
+value_	muduo/base/Singleton.h	/^T* Singleton<T>::value_ = NULL;$/;"	m	class:muduo::Singleton
+valuelen_	examples/memcached/client/bench.cc	/^  const int valuelen_;$/;"	m	class:Client	file:
+valuelen_	examples/memcached/server/Item.h	/^  const int      valuelen_;$/;"	m	class:Item
+verify	examples/sudoku/client.cc	/^bool verify(const string& result)$/;"	f
+version	examples/fastcgi/fastcgi.cc	/^  uint8_t version;$/;"	m	struct:FastCgiCodec::RecordHeader	file:
+version_	muduo/net/http/HttpRequest.h	/^  Version version_;$/;"	m	class:muduo::net::HttpRequest
+wait	muduo/base/Condition.h	/^  void wait()$/;"	f	class:muduo::Condition
+wait	muduo/base/CountDownLatch.cc	/^void CountDownLatch::wait()$/;"	f	class:CountDownLatch
+waitForSeconds	muduo/base/Condition.cc	/^bool muduo::Condition::waitForSeconds(int seconds)$/;"	f	class:muduo::Condition
+wakeup	muduo/net/EventLoop.cc	/^void EventLoop::wakeup()$/;"	f	class:EventLoop
+wakeupChannel_	muduo/net/EventLoop.h	/^  boost::scoped_ptr<Channel> wakeupChannel_;$/;"	m	class:muduo::net::EventLoop
+wakeupFd_	muduo/net/EventLoop.h	/^  int wakeupFd_;$/;"	m	class:muduo::net::EventLoop
+weakConn_	examples/idleconnection/echo.h	/^    WeakTcpConnectionPtr weakConn_;$/;"	m	struct:EchoServer::Entry
+weekDay	muduo/base/Date.h	/^  int weekDay() const$/;"	f	class:muduo::Date
+what	muduo/base/Exception.cc	/^const char* Exception::what() const throw()$/;"	f	class:Exception
+whichClient	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/DataEvent.java	/^    public final int whichClient;$/;"	f	class:DataEvent
+wkTid_	muduo/base/Thread.cc	/^  boost::weak_ptr<pid_t> wkTid_;$/;"	m	struct:muduo::detail::ThreadData	file:
+word	examples/wordcount/gen.py	/^	word = ''.join(arr)$/;"	v
+word_len	examples/wordcount/gen.py	/^word_len = 5$/;"	v
+wordcounts_	examples/wordcount/receiver.cc	/^  WordCountMap wordcounts_;$/;"	m	class:WordCountReceiver	file:
+words	examples/wordcount/gen.py	/^words = 1000000$/;"	v
+worker	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/MockBackendServer.java	/^    private final Executor worker;$/;"	f	class:MockBackendServer	file:
+worker	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/MockClient.java	/^    private final Executor worker;$/;"	f	class:MockClient	file:
+worker	examples/multiplexer/harness/src/com/chenshuo/muduo/example/multiplexer/MultiplexerTest.java	/^    private final ExecutorService worker;$/;"	f	class:MultiplexerTest	file:
+writableBytes	muduo/net/Buffer.h	/^  size_t writableBytes() const$/;"	f	class:muduo::net::Buffer
+write	examples/asio/chat/client.cc	/^  void write(const StringPiece& message)$/;"	f	class:ChatClient
+write	muduo/base/LogFile.cc	/^  size_t write(const char* logline, size_t len)$/;"	f	class:LogFile::File	file:
+write	muduo/net/SocketsOps.cc	/^ssize_t sockets::write(int sockfd, const void *buf, size_t count)$/;"	f	class:sockets
+writeCallback_	muduo/net/Channel.h	/^  EventCallback writeCallback_;$/;"	m	class:muduo::net::Channel
+writeCompleteCallback_	muduo/net/TcpClient.h	/^  WriteCompleteCallback writeCompleteCallback_;$/;"	m	class:muduo::net::TcpClient
+writeCompleteCallback_	muduo/net/TcpConnection.h	/^  WriteCompleteCallback writeCompleteCallback_;$/;"	m	class:muduo::net::TcpConnection
+writeCompleteCallback_	muduo/net/TcpServer.h	/^  WriteCompleteCallback writeCompleteCallback_;$/;"	m	class:muduo::net::TcpServer
+writeData	examples/curl/Curl.cc	/^size_t Request::writeData(char* buffer, size_t size, size_t nmemb, void* userp)$/;"	f	class:Request
+writerIndex_	muduo/net/Buffer.h	/^  size_t writerIndex_;$/;"	m	class:muduo::net::Buffer
+writtenBytes	muduo/base/LogFile.cc	/^  size_t writtenBytes() const { return writtenBytes_; }$/;"	f	class:LogFile::File
+writtenBytes_	muduo/base/LogFile.cc	/^  size_t writtenBytes_;$/;"	m	class:LogFile::File	file:
+x	muduo/base/tests/Fork_test.cc	/^__thread int x = 0;$/;"	m	namespace:__anon7	file:
+x_	muduo/base/tests/Thread_test.cc	/^  double x_;$/;"	m	class:Foo	file:
+year	muduo/base/Date.h	/^    int year; \/\/ [1900..2500]$/;"	m	struct:muduo::Date::YearMonthDay
+year	muduo/base/Date.h	/^  int year() const$/;"	f	class:muduo::Date
+yearMonthDay	muduo/base/Date.cc	/^Date::YearMonthDay Date::yearMonthDay() const$/;"	f	class:Date
+zero	muduo/base/LogStream.cc	/^const char* zero = digits + 9;$/;"	m	namespace:muduo::detail	file:
+~Acceptor	muduo/net/Acceptor.cc	/^Acceptor::~Acceptor()$/;"	f	class:Acceptor
+~AsyncLogging	muduo/base/AsyncLogging.h	/^  ~AsyncLogging()$/;"	f	class:muduo::AsyncLogging
+~Callback	examples/protobuf/codec/dispatcher.h	/^  virtual ~Callback() {};$/;"	f	class:Callback
+~Channel	muduo/net/Channel.cc	/^Channel::~Channel()$/;"	f	class:Channel
+~Condition	muduo/base/Condition.h	/^  ~Condition()$/;"	f	class:muduo::Condition
+~Connector	muduo/net/Connector.cc	/^Connector::~Connector()$/;"	f	class:Connector
+~Curl	examples/curl/Curl.cc	/^Curl::~Curl()$/;"	f	class:Curl
+~Deleter	muduo/base/ThreadLocalSingleton.h	/^    ~Deleter()$/;"	f	class:muduo::ThreadLocalSingleton::Deleter
+~EPollPoller	muduo/net/poller/EPollPoller.cc	/^EPollPoller::~EPollPoller()$/;"	f	class:EPollPoller
+~Entry	examples/idleconnection/echo.h	/^    ~Entry()$/;"	f	struct:EchoServer::Entry
+~EventLoop	muduo/net/EventLoop.cc	/^EventLoop::~EventLoop()$/;"	f	class:EventLoop
+~EventLoopThread	muduo/net/EventLoopThread.cc	/^EventLoopThread::~EventLoopThread()$/;"	f	class:EventLoopThread
+~EventLoopThreadPool	muduo/net/EventLoopThreadPool.cc	/^EventLoopThreadPool::~EventLoopThreadPool()$/;"	f	class:EventLoopThreadPool
+~Exception	muduo/base/Exception.cc	/^Exception::~Exception() throw ()$/;"	f	class:Exception
+~File	muduo/base/LogFile.cc	/^  ~File()$/;"	f	class:LogFile::File
+~File	muduo/base/TimeZone.cc	/^  ~File()$/;"	f	class:muduo::detail::File
+~FixedBuffer	muduo/base/LogStream.h	/^  ~FixedBuffer()$/;"	f	class:muduo::detail::FixedBuffer
+~HttpServer	muduo/net/http/HttpServer.cc	/^HttpServer::~HttpServer()$/;"	f	class:HttpServer
+~Inspector	muduo/net/inspect/Inspector.cc	/^Inspector::~Inspector()$/;"	f	class:Inspector
+~Item	examples/memcached/server/Item.h	/^  ~Item()$/;"	f	class:Item
+~LogFile	muduo/base/LogFile.cc	/^LogFile::~LogFile()$/;"	f	class:LogFile
+~Logger	muduo/base/Logging.cc	/^Logger::~Logger()$/;"	f	class:Logger
+~MemcacheServer	examples/memcached/server/MemcacheServer.cc	/^MemcacheServer::~MemcacheServer()$/;"	f	class:MemcacheServer
+~MutexLock	muduo/base/Mutex.h	/^  ~MutexLock()$/;"	f	class:muduo::MutexLock
+~MutexLockGuard	muduo/base/Mutex.h	/^  ~MutexLockGuard()$/;"	f	class:muduo::MutexLockGuard
+~PollPoller	muduo/net/poller/PollPoller.cc	/^PollPoller::~PollPoller()$/;"	f	class:PollPoller
+~Poller	muduo/net/Poller.cc	/^Poller::~Poller()$/;"	f	class:Poller
+~Printer	examples/asio/tutorial/timer4/timer.cc	/^  ~Printer()$/;"	f	class:Printer
+~Printer	examples/asio/tutorial/timer5/timer.cc	/^  ~Printer()$/;"	f	class:Printer
+~Printer	examples/asio/tutorial/timer6/timer.cc	/^  ~Printer()$/;"	f	class:Printer
+~Request	examples/curl/Curl.cc	/^Request::~Request()$/;"	f	class:Request
+~Resolver	examples/cdns/Resolver.cc	/^Resolver::~Resolver()$/;"	f	class:Resolver
+~RpcChannel	muduo/net/protorpc/RpcChannel.cc	/^RpcChannel::~RpcChannel()$/;"	f	class:RpcChannel
+~Session	examples/memcached/server/Session.h	/^  ~Session()$/;"	f	class:Session
+~SmallFile	muduo/base/FileUtil.cc	/^FileUtil::SmallFile::~SmallFile()$/;"	f	class:FileUtil::SmallFile
+~Socket	muduo/net/Socket.cc	/^Socket::~Socket()$/;"	f	class:Socket
+~TcpClient	muduo/net/TcpClient.cc	/^TcpClient::~TcpClient()$/;"	f	class:TcpClient
+~TcpConnection	muduo/net/TcpConnection.cc	/^TcpConnection::~TcpConnection()$/;"	f	class:TcpConnection
+~TcpServer	muduo/net/TcpServer.cc	/^TcpServer::~TcpServer()$/;"	f	class:TcpServer
+~Test	muduo/base/tests/SingletonThreadLocal_test.cc	/^  ~Test()$/;"	f	class:Test
+~Test	muduo/base/tests/Singleton_test.cc	/^  ~Test()$/;"	f	class:Test
+~Test	muduo/base/tests/ThreadLocalSingleton_test.cc	/^  ~Test()$/;"	f	class:Test
+~Test	muduo/base/tests/ThreadLocal_test.cc	/^  ~Test()$/;"	f	class:Test
+~Thread	muduo/base/Thread.cc	/^Thread::~Thread()$/;"	f	class:Thread
+~ThreadLocal	muduo/base/ThreadLocal.h	/^  ~ThreadLocal()$/;"	f	class:muduo::ThreadLocal
+~ThreadPool	muduo/base/ThreadPool.cc	/^ThreadPool::~ThreadPool()$/;"	f	class:ThreadPool
+~TimerQueue	muduo/net/TimerQueue.cc	/^TimerQueue::~TimerQueue()$/;"	f	class:TimerQueue
+~Tunnel	examples/socks4a/tunnel.h	/^  ~Tunnel()$/;"	f	class:Tunnel
+~UnassignGuard	muduo/base/Mutex.h	/^    ~UnassignGuard()$/;"	f	class:muduo::MutexLock::UnassignGuard


### PR DESCRIPTION
对于一个socket，调用write的时候可能返回EINTR或者EAGIN，这两种情况下应该都可以继续使用socket，其他错误码才需要终止，另外对于read的情况下，也同样需要处理EINTR和EAGIN这两种情况。可以通过man read 和man write查看。
