### PR TITLE
fix typo BuardedBy->GuardedBy

### DIFF
--- a/muduo/net/EventLoop.h
+++ b/muduo/net/EventLoop.h
@@ -152,7 +152,7 @@ class EventLoop : boost::noncopyable
   ChannelList activeChannels_;
   Channel* currentActiveChannel_;
   MutexLock mutex_;
-  std::vector<Functor> pendingFunctors_; // @BuardedBy mutex_
+  std::vector<Functor> pendingFunctors_; // @GuardedBy mutex_
 };
 
 }

--- a/muduo/net/TcpClient.h
+++ b/muduo/net/TcpClient.h
@@ -89,7 +89,7 @@ class TcpClient : boost::noncopyable
   // always in loop thread
   int nextConnId_;
   mutable MutexLock mutex_;
-  TcpConnectionPtr connection_; // @BuardedBy mutex_
+  TcpConnectionPtr connection_; // @GuardedBy mutex_
 };
 
 }


### PR DESCRIPTION
fix typo from "@BuardedBy" to "@GuardedBy" in comment.
