### PR TITLE
Update a comment in Buffer.cc

### DIFF
--- a/muduo/net/Buffer.cc
+++ b/muduo/net/Buffer.cc
@@ -33,6 +33,7 @@ ssize_t Buffer::readFd(int fd, int* savedErrno)
   vec[1].iov_base = extrabuf;
   vec[1].iov_len = sizeof extrabuf;
   // when there is enough space in this buffer, don't read into extrabuf.
+  // when extrabuf is used, we read 128k-1 bytes at most.
   const int iovcnt = (writable < sizeof extrabuf) ? 2 : 1;
   const ssize_t n = sockets::readv(fd, vec, iovcnt);
   if (n < 0)


### PR DESCRIPTION
It seems that if writable bytes in the buffer is larger than 128k, then more than 128k will be read? If so, I think the comment "128k-1 bytes at most" is not accurate.
