### PR TITLE
fix a compile warning

### DIFF
--- a/muduo/net/TimerQueue.cc
+++ b/muduo/net/TimerQueue.cc
@@ -6,7 +6,10 @@
 
 // Author: Shuo Chen (chenshuo at chenshuo dot com)
 
+#ifndef __STDC_LIMIT_MACROS
 #define __STDC_LIMIT_MACROS
+#endif
+
 #include <muduo/net/TimerQueue.h>
 
 #include <muduo/base/Logging.h>


### PR DESCRIPTION
This patch fixes a compile warning in a build system where the macro __STDC_LIMIT_MACROS is predefined.
