### PR TITLE
Zieckey patch sockets ops

### DIFF
--- a/muduo/net/SocketsOps.cc
+++ b/muduo/net/SocketsOps.cc
@@ -27,15 +27,6 @@ namespace
 
 typedef struct sockaddr SA;
 
-const SA* sockaddr_cast(const struct sockaddr_in* addr)
-{
-  return static_cast<const SA*>(implicit_cast<const void*>(addr));
-}
-
-SA* sockaddr_cast(struct sockaddr_in* addr)
-{
-  return static_cast<SA*>(implicit_cast<void*>(addr));
-}
 
 #if VALGRIND
 void setNonBlockAndCloseOnExec(int sockfd)
@@ -56,6 +47,43 @@ void setNonBlockAndCloseOnExec(int sockfd)
 }
 #endif
 
+}
+
+const struct sockaddr* sockets::sockaddr_cast(const struct sockaddr_in* addr)
+{
+  return static_cast<const struct sockaddr*>(implicit_cast<const void*>(addr));
+}
+
+struct sockaddr* sockets::sockaddr_cast(struct sockaddr_in* addr)
+{
+  return static_cast<struct sockaddr*>(implicit_cast<void*>(addr));
+}
+
+const struct sockaddr_in* sockets::sockaddr_in_cast(const struct sockaddr* addr)
+{
+  return static_cast<const struct sockaddr_in*>(implicit_cast<const void*>(addr));
+}
+
+struct sockaddr_in* sockets::sockaddr_in_cast(struct sockaddr* addr)
+{
+  return static_cast<struct sockaddr_in*>(implicit_cast<void*>(addr));
+}
+
+
+bool sockets::setNonblocking(int sockfd) 
+{
+  int flags = fcntl(sockfd, F_GETFL, 0);
+  if (flags < 0)
+  {
+    return false;
+  }
+
+  flags = flags | O_NONBLOCK;
+  if (fcntl(sockfd, F_SETFL, flags) < 0)
+  {
+    return false;
+  }
+  return true;
 }
 
 int sockets::createNonblockingOrDie()

--- a/muduo/net/SocketsOps.h
+++ b/muduo/net/SocketsOps.h
@@ -44,6 +44,13 @@ void fromIpPort(const char* ip, uint16_t port,
 
 int getSocketError(int sockfd);
 
+const struct sockaddr* sockaddr_cast(const struct sockaddr_in* addr);
+struct sockaddr* sockaddr_cast(struct sockaddr_in* addr);
+const struct sockaddr_in* sockaddr_in_cast(const struct sockaddr* addr);
+struct sockaddr_in* sockaddr_in_cast(struct sockaddr* addr);
+
+bool setNonblocking(int sockfd);
+
 struct sockaddr_in getLocalAddr(int sockfd);
 struct sockaddr_in getPeerAddr(int sockfd);
 bool isSelfConnect(int sockfd);


### PR DESCRIPTION
As explained in another topic 

Although we need to hide the detail of interface, we may use muduo as basic network library, so the application layer can use these utility functions. 
For example, we are writting a pernal VPN server based on muduo. This server transfers TCP and UDP data as proxy.
