### PR TITLE
fix CMake error about pthread

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 2.6)
 
-project(muduo CXX)
+project(muduo C CXX)
 
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE "Debug")


### PR DESCRIPTION
Looking for include file pthread.h - not found
Could NOT find Threads (missing:  Threads_FOUND)
