### PR TITLE
Add more interface for EventLoopThreadPool

### DIFF
--- a/muduo/net/EventLoopThreadPool.cc
+++ b/muduo/net/EventLoopThreadPool.cc
@@ -68,6 +68,18 @@ EventLoop* EventLoopThreadPool::getNextLoop()
   return loop;
 }
 
+EventLoop* EventLoopThreadPool::getLoopForHash(size_t hashCode)
+{
+  baseLoop_->assertInLoopThread();
+  EventLoop* loop = baseLoop_;
+
+  if (!loops_.empty())
+  {
+    loop = loops_[hashCode % loops_.size()];
+  }
+  return loop;
+}
+
 std::vector<EventLoop*> EventLoopThreadPool::getAllLoops()
 {
   baseLoop_->assertInLoopThread();

--- a/muduo/net/EventLoopThreadPool.h
+++ b/muduo/net/EventLoopThreadPool.h
@@ -34,10 +34,18 @@ class EventLoopThreadPool : boost::noncopyable
   ~EventLoopThreadPool();
   void setThreadNum(int numThreads) { numThreads_ = numThreads; }
   void start(const ThreadInitCallback& cb = ThreadInitCallback());
+
   // valid after calling start()
+  /// round-robin
   EventLoop* getNextLoop();
-  // valid after calling start()
+
+  /// with the same hash code, it will always return the same EventLoop
+  EventLoop* getLoopForHash(size_t hashCode);
+
   std::vector<EventLoop*> getAllLoops();
+
+  bool started() const
+  { return started_; }
 
  private:
 


### PR DESCRIPTION
  EventLoop\* getLoopForHash(size_t hashCode);
  bool started() const;

On some occasions, we need to process some tasks with the same type
always in the same working thread.
