### PR TITLE
Fix coredump problem described at pull request #80.

### DIFF
--- a/examples/asio/tutorial/timer5/timer.cc
+++ b/examples/asio/tutorial/timer5/timer.cc
@@ -67,8 +67,13 @@ int main()
 {
   muduo::net::EventLoop loop;
   muduo::net::EventLoopThread loopThread;
-  muduo::net::EventLoop* loopInAnotherThread = loopThread.startLoop();
+  muduo::net::EventLoop*& loopInAnotherThread = loopThread.startLoop();
   Printer printer(&loop, loopInAnotherThread);
   loop.loop();
+  while (loopInAnotherThread && loopInAnotherThread->looping()) {
+    std::cout << "wainting the loop in another thread to quit\n";
+    loopInAnotherThread->quit();
+    sleep(1);
+  }
 }
 

--- a/examples/asio/tutorial/timer6/timer.cc
+++ b/examples/asio/tutorial/timer6/timer.cc
@@ -105,8 +105,12 @@ int main()
 {
   muduo::net::EventLoop loop;
   muduo::net::EventLoopThread loopThread;
-  muduo::net::EventLoop* loopInAnotherThread = loopThread.startLoop();
+  muduo::net::EventLoop*& loopInAnotherThread = loopThread.startLoop();
   Printer printer(&loop, loopInAnotherThread);
   loop.loop();
+  while (loopInAnotherThread && loopInAnotherThread->looping()) {
+    loopInAnotherThread->quit();
+    sleep(1);
+  }
 }
 

--- a/muduo/net/EventLoop.h
+++ b/muduo/net/EventLoop.h
@@ -57,6 +57,8 @@ class EventLoop : boost::noncopyable
   /// better to call through shared_ptr<EventLoop> for 100% safety.
   void quit();
 
+  bool looping() const { return looping_; }
+
   ///
   /// Time when poll returns, usually means data arrival.
   ///

--- a/muduo/net/EventLoopThread.cc
+++ b/muduo/net/EventLoopThread.cc
@@ -38,7 +38,7 @@ EventLoopThread::~EventLoopThread()
   }
 }
 
-EventLoop* EventLoopThread::startLoop()
+EventLoop*& EventLoopThread::startLoop()
 {
   assert(!thread_.started());
   thread_.start();

--- a/muduo/net/EventLoopThread.h
+++ b/muduo/net/EventLoopThread.h
@@ -31,7 +31,7 @@ class EventLoopThread : boost::noncopyable
 
   EventLoopThread(const ThreadInitCallback& cb = ThreadInitCallback());
   ~EventLoopThread();
-  EventLoop* startLoop();
+  EventLoop*& startLoop();
 
  private:
   void threadFunc();


### PR DESCRIPTION
  Add EventLoop::looping() for querying the state of EventLoop.
  Modify the EventLoopThread::startLoop() return value to EventLoop*&
After the tow code adjusting, we can fix the coredump of #80 gracefully.
