### PR TITLE
Add a context binded to EventLoop.

### DIFF
--- a/muduo/net/EventLoop.h
+++ b/muduo/net/EventLoop.h
@@ -13,6 +13,7 @@
 
 #include <vector>
 
+#include <boost/any.hpp>
 #include <boost/function.hpp>
 #include <boost/noncopyable.hpp>
 #include <boost/scoped_ptr.hpp>
@@ -126,6 +127,15 @@ class EventLoop : boost::noncopyable
   // bool callingPendingFunctors() const { return callingPendingFunctors_; }
   bool eventHandling() const { return eventHandling_; }
 
+  void setContext(const boost::any& context)
+  { context_ = context; }
+
+  const boost::any& getContext() const
+  { return context_; }
+
+  boost::any* getMutableContext()
+  { return &context_; }
+
   static EventLoop* getEventLoopOfCurrentThread();
 
  private:
@@ -154,6 +164,7 @@ class EventLoop : boost::noncopyable
   Channel* currentActiveChannel_;
   MutexLock mutex_;
   std::vector<Functor> pendingFunctors_; // @GuardedBy mutex_
+  boost::any context_;
 };
 
 }


### PR DESCRIPTION
有些时候我们需要将一些数据结构绑定到特定的EventLoop上，这样可以让每个EventLoop只处理属于自己的数据，而不用与其他EventLoop共享数据，这样可以提高服务器性能。
例如muduo源码示例socks4a.cc中，对g_tunnels这个全局数据结构的操作都没有加锁，是因为该程序只是一个单线程的示例程序，如果改为多线程的话，就有问题。为了解决这个加锁的问题，最好将g_tunnels这个数据结构绑定到特定的EventLoop上。
