### PR TITLE
Add ip and port to the server response data

### DIFF
--- a/examples/socks4a/socks4a.cc
+++ b/examples/socks4a/socks4a.cc
@@ -91,6 +91,8 @@ void onServerMessage(const TcpConnectionPtr& conn, Buffer* buf, Timestamp)
           g_tunnels[conn->name()] = tunnel;
           buf->retrieveUntil(where+1);
           char response[] = "\000\x5aUVWXYZ";
+          memcpy(response+2, &addr.sin_port, 2);
+          memcpy(response+4, &addr.sin_addr.s_addr, 4);
           conn->send(response, 8);
         }
         else


### PR DESCRIPTION
Server to SOCKS4a client:

	* field 1: null byte
	* field 2: status, 1 byte:

		* 0x5a = request granted
		* 0x5b = request rejected or failed
		* 0x5c = request failed because client is not running identd (or not reachable from the server)
		* 0x5d = request failed because client's identd could not confirm the user ID string in the request

	* field 3: network byte order port number, 2 bytes
	* field 4: network byte order IP address, 4 bytes
