### PR TITLE
Fix half-closing connection bug.

### DIFF
--- a/muduo/net/TcpServer.cc
+++ b/muduo/net/TcpServer.cc
@@ -93,6 +93,7 @@ void TcpServer::newConnection(int sockfd, const InetAddress& peerAddr)
                                           localAddr,
                                           peerAddr));
   connections_[connName] = conn;
+  conn->setDirection(TcpConnection::kIncomming);
   conn->setConnectionCallback(connectionCallback_);
   conn->setMessageCallback(messageCallback_);
   conn->setWriteCompleteCallback(writeCompleteCallback_);


### PR DESCRIPTION
假如我们用muduo做一个透明proxyserver，客户端行为如下：
1. send(data)
2. shutdown(SHUT_WR)
3. recv()
4. close()
在上述第2步之后，proxyserver会收到一个READ事件，调用read返回0，在proxyserver看来，客户端正在执行一个正常的shutdown操作，因此目前的处理是直接关闭连接。
但是，这个时候，远端server可能还没有来得及将响应数据返回呢，因此会导致客户端接收不到数据或接收数据不全的问题。

目前我想到了两个解决办法：
方法一：直接将该shutdown事件反馈给应用层，让应用层处理这个问题。这个会给应用层带来额外的负担，发生错误的用法会增加很多。不太安全。同时，对muduo库来说，其行为发生改变，会导致现有的examples以及其他基于muduo的应用程序出现潜在的bug。
方法二：延时关闭连接。这个做法优点是能与现有接口兼容，对应用层无感知。缺点是，延时也不太靠谱，虽然不能完美解决这个问题，但通过暴露设置延时时间的接口给应用层，应用层就可以控制连接的具体关闭时间点。

目前这个PR采用第二种方法。请大家看看是否可行。