### PR TITLE
fix the bug when compile with clang++3.5.0

### DIFF
--- a/clang.diff
+++ b/clang.diff
@@ -1,8 +1,17 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index a3066c5..9728303 100644
+index d46e1e7..27a243c 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -16,6 +16,7 @@
+@@ -11,13 +11,15 @@ endif()
+ set(CXX_FLAGS
+  -g
+  # -DVALGRIND
+- # -DMUDUO_STD_STRING
++ -DMUDUO_STD_STRING
++ -stdlib=libc++
+  -DCHECK_PTHREAD_RETURN_VALUE
+  -D_FILE_OFFSET_BITS=64
+  -Wall
   -Wextra
   -Werror
   -Wconversion
@@ -10,7 +19,7 @@ index a3066c5..9728303 100644
   -Wno-unused-parameter
   -Wold-style-cast
   -Woverloaded-virtual
-@@ -25,16 +26,15 @@
+@@ -27,16 +29,15 @@ set(CXX_FLAGS
   -march=native
   # -MMD
   # -std=c++0x

--- a/muduo/base/Date.cc
+++ b/muduo/base/Date.cc
@@ -5,6 +5,9 @@
 
 #include <muduo/base/Date.h>
 #include <stdio.h>  // snprintf
+#ifdef _LIBCPP_VERSION
+#include <time.h>
+#endif
 
 namespace muduo
 {

--- a/muduo/base/Date.cc
+++ b/muduo/base/Date.cc
@@ -5,9 +5,7 @@
 
 #include <muduo/base/Date.h>
 #include <stdio.h>  // snprintf
-#ifdef _LIBCPP_VERSION
 #include <time.h>
-#endif
 
 namespace muduo
 {

--- a/muduo/base/Timestamp.cc
+++ b/muduo/base/Timestamp.cc
@@ -2,9 +2,7 @@
 
 #include <sys/time.h>
 #include <stdio.h>
-#ifdef _LIBCPP_VERSION
 #include <time.h>
-#endif
 
 #ifndef __STDC_FORMAT_MACROS
 #define __STDC_FORMAT_MACROS

--- a/muduo/base/Timestamp.cc
+++ b/muduo/base/Timestamp.cc
@@ -2,6 +2,9 @@
 
 #include <sys/time.h>
 #include <stdio.h>
+#ifdef _LIBCPP_VERSION
+#include <time.h>
+#endif
 
 #ifndef __STDC_FORMAT_MACROS
 #define __STDC_FORMAT_MACROS

--- a/muduo/base/tests/Date_unittest.cc
+++ b/muduo/base/tests/Date_unittest.cc
@@ -1,9 +1,7 @@
 #include <muduo/base/Date.h>
 #include <assert.h>
 #include <stdio.h>
-#ifdef _LIBCPP_VERSION
 #include <time.h>
-#endif
 
 using muduo::Date;
 

--- a/muduo/base/tests/Date_unittest.cc
+++ b/muduo/base/tests/Date_unittest.cc
@@ -1,6 +1,9 @@
 #include <muduo/base/Date.h>
 #include <assert.h>
 #include <stdio.h>
+#ifdef _LIBCPP_VERSION
+#include <time.h>
+#endif
 
 using muduo::Date;
 

--- a/muduo/base/tests/GzipFile_test.cc
+++ b/muduo/base/tests/GzipFile_test.cc
@@ -2,6 +2,10 @@
 
 #include <muduo/base/Logging.h>
 
+#ifdef _LIBCPP_VERSION
+#include <errno.h>
+#endif
+
 int main()
 {
   const char* filename = "/tmp/gzipfile_test.gz";

--- a/muduo/base/tests/GzipFile_test.cc
+++ b/muduo/base/tests/GzipFile_test.cc
@@ -2,9 +2,7 @@
 
 #include <muduo/base/Logging.h>
 
-#ifdef _LIBCPP_VERSION
 #include <errno.h>
-#endif
 
 int main()
 {


### PR DESCRIPTION
参考了（https://cplusplusmusings.wordpress.com/tag/libc/）
https://stackoverflow.com/questions/10463851/what-is-gccs-vstring


但在编译buffer_*_unittest 的时候报
[ 80%] Building CXX object muduo/net/tests/CMakeFiles/buffer_unittest.dir/Buffer_unittest.cc.o
Linking CXX executable ../../../bin/buffer_cpp11_unittest
CMakeFiles/buffer_cpp11_unittest.dir/Buffer_unittest.cc.o: In function `boost::unit_test::lazy_ostream_impl<boost::test_tools::tt_detail::print_helper_t<char const*> const&>::operator()(std::__1::basic_ostream<cha
r, std::__1::char_traits<char> >&) const':
/usr/include/boost/test/test_tools.hpp:467: undefined reference to `boost::test_tools::print_log_value<char const*>::operator()(std::__1::basic_ostream<char, std::__1::char_traits<char> >&, char const*)'
CMakeFiles/buffer_cpp11_unittest.dir/Buffer_unittest.cc.o: In function `boost::unit_test::lazy_ostream_impl<boost::test_tools::tt_detail::print_helper_t<char> const&>::operator()(std::__1::basic_ostream<char, std:
:__1::char_traits<char> >&) const':
/usr/include/boost/test/test_tools.hpp:467: undefined reference to `boost::test_tools::print_log_value<char>::operator()(std::__1::basic_ostream<char, std::__1::char_traits<char> >&, char)'
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[2]: *** [bin/buffer_cpp11_unittest] 错误 1
make[1]: *** [muduo/net/tests/CMakeFiles/buffer_cpp11_unittest.dir/all] 错误 2
make[1]: *** 正在等待未完成的任务....
Linking CXX executable ../../../bin/buffer_unittest
CMakeFiles/buffer_unittest.dir/Buffer_unittest.cc.o: In function `boost::unit_test::lazy_ostream_impl<boost::test_tools::tt_detail::print_helper_t<char const*> const&>::operator()(std::__1::basic_ostream<char, std
::__1::char_traits<char> >&) const':
/usr/include/boost/test/test_tools.hpp:467: undefined reference to `boost::test_tools::print_log_value<char const*>::operator()(std::__1::basic_ostream<char, std::__1::char_traits<char> >&, char const*)'
CMakeFiles/buffer_unittest.dir/Buffer_unittest.cc.o: In function `boost::unit_test::lazy_ostream_impl<boost::test_tools::tt_detail::print_helper_t<char> const&>::operator()(std::__1::basic_ostream<char, std::__1::
char_traits<char> >&) const':
/usr/include/boost/test/test_tools.hpp:467: undefined reference to `boost::test_tools::print_log_value<char>::operator()(std::__1::basic_ostream<char, std::__1::char_traits<char> >&, char)'
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[2]: *** [bin/buffer_unittest] 错误 1
make[1]: *** [muduo/net/tests/CMakeFiles/buffer_unittest.dir/all] 错误 2
make: *** [all] 错误 2

**猜测是boost_test库与clang链接时的错误，g++时未报错，但是不影响用clang++编译muduo库本身。所以还是提个 pull request**