### PR TITLE
Enhance the robustness

### DIFF
--- a/muduo/net/poller/EPollPoller.cc
+++ b/muduo/net/poller/EPollPoller.cc
@@ -123,8 +123,12 @@ void EPollPoller::updateChannel(Channel* channel)
       assert(channels_.find(fd) != channels_.end());
       assert(channels_[fd] == channel);
     }
-    channel->set_index(kAdded);
-    update(EPOLL_CTL_ADD, channel);
+
+    if (!channel->isNoneEvent())
+    {
+      channel->set_index(kAdded);
+      update(EPOLL_CTL_ADD, channel);
+    }
   }
   else
   {


### PR DESCRIPTION
server端一开始是监听reading事件的，
当应用层读完所有数据的时候，应用层可能会调用 channel->disableReading() 
EPollPoller.cc:updateChannel 逻辑会将该 channel->fd_ 从 epoll 中移出。

当Client端断开连接时，会依次调用 
TcpConnection::handleClose()、channel->disableReading()、EPollPoller.cc:updateChannel等
然而 EPollPoller.cc:updateChannel 这里的状态机不满足这种调用场景，又会将该 channel::fd_ 放入 epoll 中，
这样会造成不必要的系统调用，同时状态也更复杂。

因此做一个基本的检查，如果没有事件要监听的话，就不添加到epoll中。
