### PR TITLE
Prolong Client's lifetime

### DIFF
--- a/examples/memcached/client/bench.cc
+++ b/examples/memcached/client/bench.cc
@@ -69,6 +69,7 @@ class Client : boost::noncopyable
     else
     {
       conn_.reset();
+      client_.getLoop()->queueInLoop(boost::bind(&CountDownLatch::countDown, finished_));
     }
   }
 
@@ -121,7 +122,6 @@ class Client : boost::noncopyable
     if (acked_ == requests_)
     {
       conn_->shutdown();
-      finished_->countDown();
     }
   }
 


### PR DESCRIPTION
例子memcached/client/bench.cc程序退出的时存在race condition

在debug编译模式下，程序退出时有较大概率出现如下情况的core dumped：

##### 1
liyuan@liyuan:~/github/muduo/build/debug/bin$ ./memcached_bench -r 100
20150310 02:11:35.412796Z 27821 WARN  Connecting 127.0.0.1:11211 - bench.cc:196
20150310 02:11:35.412982Z 27821 WARN  estimated memcached-debug memory usage 209 MiB - bench.cc:205
20150310 02:11:35.419264Z 27821 WARN  100 clients all connected - bench.cc:228
20150310 02:11:35.615415Z 27821 WARN  All finished - bench.cc:236
20150310 02:11:35.615458Z 27821 WARN  0.196123 sec - bench.cc:238
20150310 02:11:35.615485Z 27821 WARN  50988.4103343 QPS - bench.cc:239
memcached_bench: /home/liyuan/github/muduo/muduo/muduo/net/TcpConnection.cc:72: muduo::net::TcpConnection::~TcpConnection(): Assertion `state_ == kDisconnected' failed.
Aborted (core dumped)
##### 2
liyuan@liyuan:~/github/muduo/build/debug/bin$ ./memcached_bench -r 100
20150310 02:19:15.437416Z 27870 WARN  Connecting 127.0.0.1:11211 - bench.cc:196
20150310 02:19:15.437598Z 27870 WARN  estimated memcached-debug memory usage 209 MiB - bench.cc:205
20150310 02:19:15.448982Z 27870 WARN  100 clients all connected - bench.cc:228
20150310 02:19:15.641302Z 27870 WARN  All finished - bench.cc:236
20150310 02:19:15.641344Z 27870 WARN  0.19229 sec - bench.cc:238
20150310 02:19:15.641365Z 27870 WARN  52004.7844402 QPS - bench.cc:239
memcached_bench: /home/liyuan/github/muduo/muduo/muduo/net/Channel.cc:40: muduo::net::Channel::~Channel(): Assertion `!addedToLoop_' failed.
Aborted (core dumped)
##### 3
liyuan@liyuan:~/github/muduo/build/debug/bin$ ./memcached_bench -r 100
20150310 02:20:23.884118Z 27927 WARN  Connecting 127.0.0.1:11211 - bench.cc:196
20150310 02:20:23.884282Z 27927 WARN  estimated memcached-debug memory usage 209 MiB - bench.cc:205
20150310 02:20:23.890929Z 27927 WARN  100 clients all connected - bench.cc:228
20150310 02:20:24.097930Z 27927 WARN  All finished - bench.cc:236
20150310 02:20:24.098193Z 27927 WARN  0.206966 sec - bench.cc:238
20150310 02:20:24.098296Z 27927 WARN  48317.1148884 QPS - bench.cc:239
memcached_bench: /home/liyuan/github/muduo/muduo/muduo/base/Mutex.h:81: lock: Unexpected error: Invalid argument.
Aborted (core dumped)




