### PR TITLE
Fix complie error.

### DIFF
--- a/examples/procmon/plot.cc
+++ b/examples/procmon/plot.cc
@@ -32,7 +32,7 @@ Plot::~Plot()
   gdImageDestroy(image_);
 }
 
-muduo::string Plot::plotCpu(const std::vector<double> data)
+muduo::string Plot::plotCpu(const std::vector<double>& data)
 {
   gdImageFilledRectangle(image_, 0, 0, width_, height_, background_);
   if (data.size() > 1)
@@ -99,7 +99,7 @@ void Plot::label(double maxValue)
                   blue_);
 }
 
-int Plot::getX(ssize_t i, ssize_t total) const
+int Plot::getX(long i, long total) const
 {
   double x = (width_ - kLeftMargin_ - kRightMargin_) + static_cast<double>(i - total) * ratioX_;
   return static_cast<int>(x + 0.5) + kLeftMargin_;

--- a/examples/procmon/plot.h
+++ b/examples/procmon/plot.h
@@ -9,7 +9,7 @@ class Plot : boost::noncopyable
  public:
   Plot(int width, int height, int totalSeconds, int samplingPeriod);
   ~Plot();
-  muduo::string plotCpu(const std::vector<double> data);
+  muduo::string plotCpu(const std::vector<double>& data);
 
  private:
   muduo::string toPng();


### PR DESCRIPTION
Fix compile error:

>[ 99%] Building CXX object examples/procmon/CMakeFiles/plot_test.dir/plot.cc.o
/home/liyuan/github/muduo/muduo/examples/procmon/plot.cc:102:5: error: prototype for ‘int Plot::getX(ssize_t, ssize_t) const’ does not match any in class ‘Plot’
 int Plot::getX(ssize_t i, ssize_t total) const
     ^
In file included from /home/liyuan/github/muduo/muduo/examples/procmon/plot.cc:1:0:
/home/liyuan/github/muduo/muduo/examples/procmon/plot.h:17:7: error: candidate is: int Plot::getX(long int, long int) const
   int getX(long x, long total) const;
       ^
make[2]: *** [examples/procmon/CMakeFiles/plot_test.dir/plot.cc.o] Error 1
make[1]: *** [examples/procmon/CMakeFiles/plot_test.dir/all] Error 2
make: *** [all] Error 2
