### PR TITLE
fix 'endian.h' file not found

### DIFF
--- a/MacOSX.diff
+++ b/MacOSX.diff
@@ -838,3 +838,17 @@ index f42f5a4..a6a3133 100644
    }
 +#endif
  }
+
+diff --git a/examples/protobuf/rpcbalancer/balancer_raw.cc b/examples/protobuf/rpcbalancer/balancer_raw.cc
+index 9c2e1db..c30b19d 100644
+--- a/examples/protobuf/rpcbalancer/balancer_raw.cc
++++ b/examples/protobuf/rpcbalancer/balancer_raw.cc
+@@ -12,7 +12,7 @@
+ #include <boost/bind.hpp>
+ #include <boost/ptr_container/ptr_vector.hpp>
+
+-#include <endian.h>
++#include <machine/endian.h>
+ #include <stdio.h>
+
+ using namespace muduo;


### PR DESCRIPTION
最新的master分支，patch后mac上编译报错：
/Users/hsl4125/muduo/examples/protobuf/rpcbalancer/balancer_raw.cc:15:10: fatal error:
'endian.h' file not found
#include 
^
1 error generated.