### PR TITLE
fix compiling errors due to -Werror=unused-variable under release mode

### DIFF
--- a/muduo/net/protobuf/ProtobufCodecLite.cc
+++ b/muduo/net/protobuf/ProtobufCodecLite.cc
@@ -27,7 +27,7 @@ namespace
     GOOGLE_PROTOBUF_VERIFY_VERSION;
     return 0;
   }
-  int dummy = ProtobufVersionCheck();
+  int dummy __attribute__((unused)) = ProtobufVersionCheck();
 }
 
 void ProtobufCodecLite::send(const TcpConnectionPtr& conn,

--- a/muduo/net/protorpc/RpcCodec.cc
+++ b/muduo/net/protorpc/RpcCodec.cc
@@ -27,7 +27,7 @@ namespace
     GOOGLE_PROTOBUF_VERIFY_VERSION;
     return 0;
   }
-  int dummy = ProtobufVersionCheck();
+  int dummy __attribute__((unused)) = ProtobufVersionCheck();
 }
 
 namespace muduo


### PR DESCRIPTION
compiling errors pasted below (g++ 5.2.0) :

Scanning dependencies of target ttcp_muduo
[ 42%] Building CXX object muduo/net/protobuf/CMakeFiles/muduo_protobuf_codec.dir/ProtobufCodecLite.cc.o
[ 42%] Building CXX object examples/ace/ttcp/CMakeFiles/ttcp_muduo.dir/ttcp.cc.o
/home/wangke/codes/github/muduo/muduo/net/protobuf/ProtobufCodecLite.cc:30:7: error: ‘{anonymous}::dummy’ defined but not used [-Werror=unused-variable]
int dummy = ProtobufVersionCheck();
^
cc1plus: all warnings being treated as errors
muduo/net/protobuf/CMakeFiles/muduo_protobuf_codec.dir/build.make:62: recipe for target 'muduo/net/protobuf/CMakeFiles/muduo_protobuf_codec.dir/ProtobufCodecLite.cc.o' failed
make[2]: *** [muduo/net/protobuf/CMakeFiles/muduo_protobuf_codec.dir/ProtobufCodecLite.cc.o] Error 1