### PR TITLE
add random retry delay

### DIFF
--- a/muduo/net/Connector.cc
+++ b/muduo/net/Connector.cc
@@ -43,10 +43,6 @@ Connector::~Connector()
 
 void Connector::randomRetryDelayMs()
 {
-	struct timespec tsp;
-	clock_gettime(CLOCK_REALTIME,&tsp);
-	unsigned int seed=static_cast<unsigned int>(tsp.tv_nsec);
-	srand(seed);
 	retryDelayMs_=rand()%1501+500;
 }
 

--- a/muduo/net/Connector.h
+++ b/muduo/net/Connector.h
@@ -48,6 +48,7 @@ class Connector : boost::noncopyable,
   enum States { kDisconnected, kConnecting, kConnected };
   static const int kMaxRetryDelayMs = 30*1000;
   static const int kInitRetryDelayMs = 500;
+  void randomRetryDelayMs();
 
   void setState(States s) { state_ = s; }
   void startInLoop();

--- a/muduo/net/TcpClient.cc
+++ b/muduo/net/TcpClient.cc
@@ -131,6 +131,13 @@ void TcpClient::stop()
   connector_->stop();
 }
 
+void TcpClient::enableRetry()
+{
+	unsigned int seed=static_cast<unsigned int>(time(NULL));
+	srand(seed);
+	retry_=true;
+}
+
 void TcpClient::newConnection(int sockfd)
 {
   loop_->assertInLoopThread();
@@ -175,7 +182,7 @@ void TcpClient::removeConnection(const TcpConnectionPtr& conn)
   loop_->queueInLoop(boost::bind(&TcpConnection::connectDestroyed, conn));
   if (retry_ && connect_)
   {
-    LOG_INFO << "TcpClient::connect[" << name_ << "] - Reconnecting to "
+	LOG_INFO << "TcpClient::connect[" << name_ << "] - Reconnecting to "
              << connector_->serverAddress().toIpPort();
     connector_->restart();
   }

--- a/muduo/net/TcpClient.h
+++ b/muduo/net/TcpClient.h
@@ -46,7 +46,7 @@ class TcpClient : boost::noncopyable
 
   EventLoop* getLoop() const { return loop_; }
   bool retry() const;
-  void enableRetry() { retry_ = true; }
+  void enableRetry();
 
   const string& name() const
   { return name_; }


### PR DESCRIPTION
陈老师你好，我在测试muduo并发性能时，发现您在书中提到的“TcpClient连接断开初次重试的延迟应具有随机性（0.5~2.0）秒”   此功能并没有实现出来。
经过模拟服务器崩溃重启的测试后，发现在10k个连接时，断线重连会有几百个连接丢失，在20k个连接时，则会丢失大约2千个连接。
实现初次重试延迟的随机性后再进行测试，结果是10k个连接可以完全重新连接上服务器，在20k个连接时，则会丢失大约20个连接。证明此功能的确可以提升TcpClient断线重连的健壮性，所以提出pull request，望采纳。

另外，在大于20K的连接，单机测试的情况下，断线重连时客户端程序有时会出现段错误崩溃，请问这种情况发生的原因可能会是什么？（进程最大描述符已改为500k，端口范围已改为1081-65535）

新手一枚，如有错误，望陈老师能不吝赐教。十分感谢！