### PR TITLE
fix a spelling error

### DIFF
--- a/muduo/net/Acceptor.cc
+++ b/muduo/net/Acceptor.cc
@@ -77,7 +77,7 @@ void Acceptor::handleRead()
     LOG_SYSERR << "in Acceptor::handleRead";
     // Read the section named "The special problem of
     // accept()ing when you can't" in libev's doc.
-    // By Marc Lehmann, author of livev.
+    // By Marc Lehmann, author of libev.
     if (errno == EMFILE)
     {
       ::close(idleFd_);


### PR DESCRIPTION
Fix a spelling error. Change livev to libev.