### PR TITLE
Mac build error

### DIFF
--- a/examples/protobuf/rpcbalancer/balancer_raw.cc
+++ b/examples/protobuf/rpcbalancer/balancer_raw.cc
@@ -12,7 +12,7 @@
 #include <boost/bind.hpp>
 #include <boost/ptr_container/ptr_vector.hpp>
 
-#include <endian.h>
+#include <muduo/net/endian.h>
 #include <stdio.h>
 
 using namespace muduo;


### PR DESCRIPTION
example中使用系统endian.h，应该替换成muduo 封装的 endian.h文件.