### PR TITLE
fetch queue size

### DIFF
--- a/muduo/net/EventLoop.cc
+++ b/muduo/net/EventLoop.cc
@@ -170,7 +170,7 @@ void EventLoop::queueInLoop(const Functor& cb)
   }
 }
 
-size_t EventLoop::queueSize(void)
+size_t EventLoop::queueSize() const
 {
   MutexLockGuard lock(mutex_);
   return pendingFunctors_.size();

--- a/muduo/net/EventLoop.cc
+++ b/muduo/net/EventLoop.cc
@@ -170,6 +170,12 @@ void EventLoop::queueInLoop(const Functor& cb)
   }
 }
 
+size_t EventLoop::queueSize(void)
+{
+  MutexLockGuard lock(mutex_);
+  return pendingFunctors_.size();
+}
+
 TimerId EventLoop::runAt(const Timestamp& time, const TimerCallback& cb)
 {
   return timerQueue_->addTimer(cb, time, 0.0);

--- a/muduo/net/EventLoop.h
+++ b/muduo/net/EventLoop.h
@@ -75,6 +75,8 @@ class EventLoop : boost::noncopyable
   /// Safe to call from other threads.
   void queueInLoop(const Functor& cb);
 
+  size_t queueSize(void);
+
 #ifdef __GXX_EXPERIMENTAL_CXX0X__
   void runInLoop(Functor&& cb);
   void queueInLoop(Functor&& cb);

--- a/muduo/net/EventLoop.h
+++ b/muduo/net/EventLoop.h
@@ -75,7 +75,7 @@ class EventLoop : boost::noncopyable
   /// Safe to call from other threads.
   void queueInLoop(const Functor& cb);
 
-  size_t queueSize(void);
+  size_t queueSize() const;
 
 #ifdef __GXX_EXPERIMENTAL_CXX0X__
   void runInLoop(Functor&& cb);


### PR DESCRIPTION
Sometimes we need fetch the queuesize to handle high-water case. No push if larger than one specify number. 