### PR TITLE
fix AsyncLogging::threadFunc bug

### DIFF
--- a/muduo/base/AsyncLogging.cc
+++ b/muduo/base/AsyncLogging.cc
@@ -111,7 +111,7 @@ void AsyncLogging::threadFunc()
     {
       assert(!buffersToWrite.empty());
       newBuffer1 = std::move(buffersToWrite.back());
-      buffersToWrite.back();
+      buffersToWrite.pop_back();
       newBuffer1->reset();
     }
 
@@ -119,7 +119,7 @@ void AsyncLogging::threadFunc()
     {
       assert(!buffersToWrite.empty());
       newBuffer2 = std::move(buffersToWrite.back());
-      buffersToWrite.back();
+      buffersToWrite.pop_back();
       newBuffer2->reset();
     }
 


### PR DESCRIPTION
after std::move,pop_back the last element of buffersToWrite.(My first pull request，for the errors I am very sorry)