### PR TITLE
fix reference a local variable

### DIFF
--- a/examples/pingpong/bench.cc
+++ b/examples/pingpong/bench.cc
@@ -20,7 +20,9 @@ std::vector<int> g_pipes;
 int numPipes;
 int numActive;
 int numWrites;
-EventLoop* g_loop;
+EventLoop loop;
+EventLoop* g_loop = &loop;
+
 boost::ptr_vector<Channel> g_channels;
 
 int g_reads, g_writes, g_fired;
@@ -119,8 +121,7 @@ int main(int argc, char* argv[])
     }
   }
 
-  EventLoop loop;
-  g_loop = &loop;
+
 
   for (int i = 0; i < numPipes; ++i)
   {

--- a/examples/pingpong/bench.cc
+++ b/examples/pingpong/bench.cc
@@ -20,9 +20,7 @@ std::vector<int> g_pipes;
 int numPipes;
 int numActive;
 int numWrites;
-EventLoop loop;
-EventLoop* g_loop = &loop;
-
+EventLoop* g_loop;
 boost::ptr_vector<Channel> g_channels;
 
 int g_reads, g_writes, g_fired;
@@ -121,7 +119,8 @@ int main(int argc, char* argv[])
     }
   }
 
-
+  EventLoop loop;
+  g_loop = &loop;
 
   for (int i = 0; i < numPipes; ++i)
   {
@@ -141,4 +140,5 @@ int main(int argc, char* argv[])
     it->disableAll();
     it->remove();
   }
+  g_channels.clear();
 }

--- a/examples/pingpong/bench.cc
+++ b/examples/pingpong/bench.cc
@@ -142,3 +142,4 @@ int main(int argc, char* argv[])
   }
   g_channels.clear();
 }
+


### PR DESCRIPTION
由于g_loop引用局部变量loop，导致局部变量loop析构后，boost::ptr_vector g_channels中的元素才析构，从而使用已经析构的loop，导致coredump。解决方案简单将loop定义成全局变量，延长loop生命期。