### PR TITLE
fix a bug

### DIFF
--- a/muduo/net/poller/PollPoller.cc
+++ b/muduo/net/poller/PollPoller.cc
@@ -100,6 +100,7 @@ void PollPoller::updateChannel(Channel* channel)
     assert(0 <= idx && idx < static_cast<int>(pollfds_.size()));
     struct pollfd& pfd = pollfds_[idx];
     assert(pfd.fd == channel->fd() || pfd.fd == -channel->fd()-1);
+    pfd.fd = channel->fd();
     pfd.events = static_cast<short>(channel->events());
     pfd.revents = 0;
     if (channel->isNoneEvent())


### PR DESCRIPTION
若采用PollPoller，如果channel在enableReading之后再disableReading, 再enableReading, 此Poller并没有将fd设置回来。
测试程序: 
```
#include <unistd.h>
#include <muduo/net/EventLoop.h>
#include <muduo/net/Channel.h>
#include <boost/bind.hpp>
#include <iostream>

using namespace std;

void readFromStdin(muduo::Timestamp )
{
  char buffer[1024];
  ssize_t ret = read(STDIN_FILENO, buffer, sizeof(buffer));
  buffer[ret] = '\0';
  cout << buffer;
}

int main()
{
  muduo::net::EventLoop loop;
  int fd = STDIN_FILENO;
  muduo::net::Channel channel(&loop, fd);
  channel.setReadCallback(boost::bind(&readFromStdin, _1));
  channel.enableReading();
  channel.disableReading();
  channel.enableReading();

  loop.loop();
}
```
需要设置环境变量 ```MUDUO_USE_POLL```