### PR TITLE
Fix type warning, 1e9 is a dobule type

### DIFF
--- a/muduo/base/Condition.cc
+++ b/muduo/base/Condition.cc
@@ -14,7 +14,7 @@ bool muduo::Condition::waitForSeconds(double seconds)
   // FIXME: use CLOCK_MONOTONIC or CLOCK_MONOTONIC_RAW to prevent time rewind.
   clock_gettime(CLOCK_REALTIME, &abstime);
 
-  const int64_t kNanoSecondsPerSecond = 1e9;
+  const int64_t kNanoSecondsPerSecond = 1000000000;
   int64_t nanoseconds = static_cast<int64_t>(seconds * kNanoSecondsPerSecond);
 
   abstime.tv_sec += static_cast<time_t>((abstime.tv_nsec + nanoseconds) / kNanoSecondsPerSecond);

--- a/muduo/net/tests/Channel_test.cc
+++ b/muduo/net/tests/Channel_test.cc
@@ -84,8 +84,8 @@ class PeriodicTimer
   {
     struct timespec ts;
     bzero(&ts, sizeof ts);
-    const int64_t kNanoSecondsPerSecond = 1e9;
-    const int kMinInterval = 1e5;
+    const int64_t kNanoSecondsPerSecond = 1000000000;
+    const int kMinInterval = 100000;
     int64_t nanoseconds = static_cast<int64_t>(seconds * kNanoSecondsPerSecond);
     if (nanoseconds < kMinInterval)
       nanoseconds = kMinInterval;


### PR DESCRIPTION
1e9 is a double type in some GCC version such as gcc version 4.1.2 20070115 (prerelease) (SUSE Linux), fix the warning：warning: converting to ‘int64_t’ from ‘double’