### PR TITLE
Fix bug about AsyncLogging

### DIFF
--- a/muduo/base/AsyncLogging.cc
+++ b/muduo/base/AsyncLogging.cc
@@ -132,7 +132,7 @@ void AsyncLogging::threadFunc()
 
   for (size_t i = 0; i < buffers_.size(); ++i)
   {
-    output.append(buffers_[i]->data(), buffers_[i]->length());
+    output.append(buffers_[i].data(), buffers_[i].length());
   }
 
   output.flush();

--- a/muduo/base/AsyncLogging.cc
+++ b/muduo/base/AsyncLogging.cc
@@ -124,6 +124,17 @@ void AsyncLogging::threadFunc()
     buffersToWrite.clear();
     output.flush();
   }
+
+  if (currentBuffer_)
+  {
+    output.append(currentBuffer_->data(), currentBuffer_->length());
+  }
+
+  for (size_t i = 0; i < buffers_.size(); ++i)
+  {
+    output.append(buffers_[i]->data(), buffers_[i]->length());
+  }
+
   output.flush();
 }
 


### PR DESCRIPTION
Use the following codes, write nothing to log file, in fact it should write one log message to log file.
Because AsyncLogging::stop() set running_ as false before while (running_) in AsyncLogging::threadFunc().

```cpp
#include <muduo/base/AsyncLogging.h>
#include <muduo/base/Logging.h>
#include <muduo/base/Timestamp.h>

#include <stdio.h>
#include <sys/resource.h>
#include <unistd.h>

int kRollSize = 500*1000*1000;

muduo::AsyncLogging* g_asyncLog = NULL;

void asyncOutput(const char* msg, int len)
{
  g_asyncLog->append(msg, len);
}

void bench(bool longLog)
{
  muduo::Logger::setOutput(asyncOutput);

  int cnt = 0;
  const int kBatch = 1;
  muduo::string empty = " ";
  muduo::string longStr(3000, 'X');
  longStr += " ";

  for (int t = 0; t < 1; ++t)
  {
    //muduo::Timestamp start = muduo::Timestamp::now();
    for (int i = 0; i < kBatch; ++i)
    {
      LOG_INFO << "Hello 0123456789" << " abcdefghijklmnopqrstuvwxyz "
               << (longLog ? longStr : empty)
               << cnt;
      ++cnt;
    }
    //muduo::Timestamp end = muduo::Timestamp::now();
    //printf("%f\n", timeDifference(end, start)*1000000/kBatch);
    //struct timespec ts = { 0, 500*1000*1000 };
    //nanosleep(&ts, NULL);
  }
}

int main(int argc, char* argv[])
{
  {
    // set max virtual memory to 2GB.
    size_t kOneGB = 1000*1024*1024;
    rlimit rl = { 2*kOneGB, 2*kOneGB };
    setrlimit(RLIMIT_AS, &rl);
  }

  printf("pid = %d\n", getpid());

  char name[256];
  strncpy(name, argv[0], 256);
  muduo::AsyncLogging log(::basename(name), kRollSize);
  log.start();
  g_asyncLog = &log;

  bool longLog = argc > 1;
  bench(longLog);
}

```