### PR TITLE
Improve codes to support large log file on 32-bit host

### DIFF
--- a/muduo/base/AsyncLogging.cc
+++ b/muduo/base/AsyncLogging.cc
@@ -7,7 +7,7 @@
 using namespace muduo;
 
 AsyncLogging::AsyncLogging(const string& basename,
-                           size_t rollSize,
+                           off_t rollSize,
                            int flushInterval)
   : flushInterval_(flushInterval),
     running_(false),

--- a/muduo/base/AsyncLogging.h
+++ b/muduo/base/AsyncLogging.h
@@ -21,7 +21,7 @@ class AsyncLogging : boost::noncopyable
  public:
 
   AsyncLogging(const string& basename,
-               size_t rollSize,
+               off_t rollSize,
                int flushInterval = 3);
 
   ~AsyncLogging()
@@ -63,7 +63,7 @@ class AsyncLogging : boost::noncopyable
   const int flushInterval_;
   bool running_;
   string basename_;
-  size_t rollSize_;
+  off_t rollSize_;
   muduo::Thread thread_;
   muduo::CountDownLatch latch_;
   muduo::MutexLock mutex_;

--- a/muduo/base/FileUtil.h
+++ b/muduo/base/FileUtil.h
@@ -74,7 +74,7 @@ class AppendFile : boost::noncopyable
 
   void flush();
 
-  size_t writtenBytes() const { return writtenBytes_; }
+  off_t writtenBytes() const { return writtenBytes_; }
 
  private:
 
@@ -82,7 +82,7 @@ class AppendFile : boost::noncopyable
 
   FILE* fp_;
   char buffer_[64*1024];
-  size_t writtenBytes_;
+  off_t writtenBytes_;
 };
 }
 

--- a/muduo/base/LogFile.cc
+++ b/muduo/base/LogFile.cc
@@ -10,7 +10,7 @@
 using namespace muduo;
 
 LogFile::LogFile(const string& basename,
-                 size_t rollSize,
+                 off_t rollSize,
                  bool threadSafe,
                  int flushInterval,
                  int checkEveryN)

--- a/muduo/base/LogFile.h
+++ b/muduo/base/LogFile.h
@@ -19,7 +19,7 @@ class LogFile : boost::noncopyable
 {
  public:
   LogFile(const string& basename,
-          size_t rollSize,
+          off_t rollSize,
           bool threadSafe = true,
           int flushInterval = 3,
           int checkEveryN = 1024);
@@ -35,7 +35,7 @@ class LogFile : boost::noncopyable
   static string getLogFileName(const string& basename, time_t* now);
 
   const string basename_;
-  const size_t rollSize_;
+  const off_t rollSize_;
   const int flushInterval_;
   const int checkEveryN_;
 

--- a/muduo/base/tests/AsyncLogging_test.cc
+++ b/muduo/base/tests/AsyncLogging_test.cc
@@ -6,7 +6,7 @@
 #include <sys/resource.h>
 #include <unistd.h>
 
-int kRollSize = 500*1000*1000;
+off_t kRollSize = 500*1000*1000;
 
 muduo::AsyncLogging* g_asyncLog = NULL;
 


### PR DESCRIPTION
For file size, use off_t is better than size_t
- size_t is always 32-bit on 32-bit host
- off_t is 64-bit on 32-bit host if `#define _FILE_OFFSET_BITS 64`, default 32-bit