### PR TITLE
Fix async logging

### DIFF
--- a/muduo/base/AsyncLogging.cc
+++ b/muduo/base/AsyncLogging.cc
@@ -126,6 +126,12 @@ void AsyncLogging::threadFunc()
     buffersToWrite.clear();
     output.flush();
   }
+  {
+    muduo::MutexLockGuard lock(mutex_);
+    output.append(currentBuffer_->data(), currentBuffer_->length());
+    for (const auto& val : buffers_)
+      output.append(val->data(), val->length());
+  }
   output.flush();
 }
 

--- a/muduo/base/AsyncLogging.h
+++ b/muduo/base/AsyncLogging.h
@@ -46,6 +46,10 @@ class AsyncLogging : noncopyable
     thread_.join();
   }
 
+  void flush() {
+    stop();
+  }
+
  private:
 
   void threadFunc();


### PR DESCRIPTION
1. 我觉得 `AsyncLogging` 应该加一个 `flush` 函数, 该函数仅仅调用 `stop()` 即可, 供此处

 <https://github.com/chenshuo/muduo/blob/842813d58eef6a86f53d14f560401446e2388368/muduo/base/Logging.cc#L199>

使用, 确保即使系统异常退出, 日志线程也可以正常退出, 包括刷新缓冲, 否则, 上面的代码只是刷新标准输出而已.

2. 日志线程运行到下面的代码时, 并不能保证所有的日志都以存入缓冲或写入文件, 因为 `currentBuffer_` 或 `buffers_` 中可能还有日志未处理, 可以在循环之后, 再读取上面两部分的日志.

<https://github.com/chenshuo/muduo/blob/842813d58eef6a86f53d14f560401446e2388368/muduo/base/AsyncLogging.cc#L129>

修改内容见代码, 以下是一段测试程序:

```
#include <muduo/base/AsyncLogging.h>
#include <muduo/base/Logging.h>

muduo::AsyncLogging log_thread("file_name", 1024);

void output(const char* st, int len) {
  log_thread.append(st, len);
}

void flush() {
  log_thread.flush();
}

int main() {
  
  muduo::Logger::setOutput(output);
  muduo::Logger::setFlush(flush);

  log_thread.start();
  LOG_FATAL << "test LOG_FATAL";

  return 0;
}
```


