### PR TITLE
optimize：support for single log message bigger than muduo::detail::kLargeBuffer

### DIFF
--- a/ChangeLog2
+++ b/ChangeLog2
@@ -1,6 +1,6 @@
-2018-??-??   Shuo Chen  <chenshuo@chenshuo.com>
+2018-10-24   Shuo Chen  <chenshuo@chenshuo.com>
   * First release of C++11 version of muduo.
-  * Forked after v1.0.9, e6c04c43 is the base.
+  * Forked after v1.0.9, e6c04c43 is the base. changes in cpp98 branch are integrated
   * Replace boost::shared_ptr/boost::weak_ptr with std::shared_ptr/std::weak_ptr.
   * Replace boost::function/boost::bind with std::function/std::bind/lambda.
   * Replace boost::ptr_vector<T> with std::vector<std::unique_ptr<T>>.

--- a/muduo/base/AsyncLogging.cc
+++ b/muduo/base/AsyncLogging.cc
@@ -125,7 +125,7 @@ void AsyncLogging::append_unlocked(const char* buf, int len)
   mutex_.assertLocked();
   while (len > kBufferSize)
   {
-      append(buf, kBufferSize);
+      append_unlocked(buf, kBufferSize);
       buf += kBufferSize;
       len -= kBufferSize;
   }

--- a/muduo/base/AsyncLogging.h
+++ b/muduo/base/AsyncLogging.h
@@ -54,7 +54,7 @@ class AsyncLogging : noncopyable
  private:
 
   void threadFunc();
-  void append_unlocked(const char* buf, int len);
+  void append_unlocked(const char* buf, int len) REQUIRES(mutex_);
 
   static const int kBufferSize = muduo::detail::kLargeBuffer;
   typedef muduo::detail::FixedBuffer<kBufferSize> Buffer;

--- a/muduo/base/AsyncLogging.h
+++ b/muduo/base/AsyncLogging.h
@@ -54,8 +54,10 @@ class AsyncLogging : noncopyable
  private:
 
   void threadFunc();
+  void append_unlocked(const char* buf, int len);
 
-  typedef muduo::detail::FixedBuffer<muduo::detail::kLargeBuffer> Buffer;
+  static const int kBufferSize = muduo::detail::kLargeBuffer;
+  typedef muduo::detail::FixedBuffer<kBufferSize> Buffer;
   typedef std::vector<std::unique_ptr<Buffer>> BufferVector;
   typedef BufferVector::value_type BufferPtr;
 

--- a/muduo/base/tests/BlockingQueue_bench.cc
+++ b/muduo/base/tests/BlockingQueue_bench.cc
@@ -13,9 +13,9 @@ class Bench
 {
  public:
   Bench(int numThreads)
-    : latch_(numThreads),
-      threads_(numThreads)
+    : latch_(numThreads)
   {
+    threads_.reserve(numThreads);
     for (int i = 0; i < numThreads; ++i)
     {
       char name[32];

--- a/muduo/base/tests/BoundedBlockingQueue_test.cc
+++ b/muduo/base/tests/BoundedBlockingQueue_test.cc
@@ -13,8 +13,7 @@ class Test
  public:
   Test(int numThreads)
     : queue_(20),
-      latch_(numThreads),
-      threads_(numThreads)
+      latch_(numThreads)
   {
     for (int i = 0; i < numThreads; ++i)
     {


### PR DESCRIPTION
AsyncLogging单条日志的大小受到muduo::detail::kLargeBuffer的限制，超过此大小的日志是写不进去的