### PR TITLE
Optimize：support for single log message bigger than muduo::detail::kLargeBuffer

### DIFF
--- a/muduo/base/AsyncLogging.cc
+++ b/muduo/base/AsyncLogging.cc
@@ -125,7 +125,7 @@ void AsyncLogging::append_unlocked(const char* buf, int len)
   mutex_.assertLocked();
   while (len > kBufferSize)
   {
-      append(buf, kBufferSize);
+      append_unlocked(buf, kBufferSize);
       buf += kBufferSize;
       len -= kBufferSize;
   }

--- a/muduo/base/AsyncLogging.h
+++ b/muduo/base/AsyncLogging.h
@@ -54,7 +54,7 @@ class AsyncLogging : noncopyable
  private:
 
   void threadFunc();
-  void append_unlocked(const char* buf, int len);
+  void append_unlocked(const char* buf, int len) REQUIRES(mutex_);
 
   static const int kBufferSize = muduo::detail::kLargeBuffer;
   typedef muduo::detail::FixedBuffer<kBufferSize> Buffer;

--- a/muduo/base/AsyncLogging.h
+++ b/muduo/base/AsyncLogging.h
@@ -54,8 +54,10 @@ class AsyncLogging : noncopyable
  private:
 
   void threadFunc();
+  void append_unlocked(const char* buf, int len);
 
-  typedef muduo::detail::FixedBuffer<muduo::detail::kLargeBuffer> Buffer;
+  static const int kBufferSize = muduo::detail::kLargeBuffer;
+  typedef muduo::detail::FixedBuffer<kBufferSize> Buffer;
   typedef std::vector<std::unique_ptr<Buffer>> BufferVector;
   typedef BufferVector::value_type BufferPtr;
 


### PR DESCRIPTION
AsyncLoggin单条日志的大小受到muduo::detail::kLargeBuffer的限制，超过此大小的日志写不进去