### PR TITLE
Fix muduo::noncopyable can't found

### DIFF
--- a/contrib/hiredis/Hiredis.h
+++ b/contrib/hiredis/Hiredis.h
@@ -1,6 +1,7 @@
 #ifndef MUDUO_CONTRIB_HIREDIS_HIREDIS_H
 #define MUDUO_CONTRIB_HIREDIS_HIREDIS_H
 
+#include <muduo/base/noncopyable.h>
 #include <muduo/base/StringPiece.h>
 #include <muduo/base/Types.h>
 #include <muduo/net/Callbacks.h>

--- a/muduo/net/InetAddress.cc
+++ b/muduo/net/InetAddress.cc
@@ -139,3 +139,11 @@ bool InetAddress::resolve(StringArg hostname, InetAddress* out)
     return false;
   }
 }
+
+void InetAddress::setScopeId(uint32_t scope_id)
+{
+  if (family() == AF_INET6)
+  {
+    addr6_.sin6_scope_id = scope_id;
+  }
+}

--- a/muduo/net/InetAddress.h
+++ b/muduo/net/InetAddress.h
@@ -69,6 +69,9 @@ class InetAddress : public muduo::copyable
   static bool resolve(StringArg hostname, InetAddress* result);
   // static std::vector<InetAddress> resolveAll(const char* hostname, uint16_t port = 0);
 
+  // set IPv6 ScopeID
+  void setScopeId(uint32_t scope_id);
+
  private:
   union
   {


### PR DESCRIPTION
缺少头文件，导致 muduo::noncopyable 未能被找到。