### PR TITLE
InetAddress support IPv6 ScopeID

### DIFF
--- a/muduo/net/InetAddress.cc
+++ b/muduo/net/InetAddress.cc
@@ -139,3 +139,11 @@ bool InetAddress::resolve(StringArg hostname, InetAddress* out)
     return false;
   }
 }
+
+void InetAddress::setScopeId(uint32_t scope_id)
+{
+  if (family() == AF_INET6)
+  {
+    addr6_.sin6_scope_id = scope_id;
+  }
+}

--- a/muduo/net/InetAddress.h
+++ b/muduo/net/InetAddress.h
@@ -69,6 +69,9 @@ class InetAddress : public muduo::copyable
   static bool resolve(StringArg hostname, InetAddress* result);
   // static std::vector<InetAddress> resolveAll(const char* hostname, uint16_t port = 0);
 
+  // set IPv6 ScopeID
+  void setScopeId(uint32_t scope_id);
+
  private:
   union
   {


### PR DESCRIPTION
使用IPv6连接有时需要设置scope id，例如：
```cpp 
InetAddress addr("fe80::20c:29ff:fefa:3790", 8888, true);  // IP地址为本地IP
int fd = sockets::createNonblockingOrDie(AF_INET6);
Socket sock(fd);
sock.bindAddress(addr);
```
如果不设置scope id会导致bind失败。
> FATAL Invalid argument (errno=22) sockets::bindOrDie

如果使用现在的接口来写，很是麻烦，getSockAddr获得的是const sockaddr*。
需要去const、转类型、赋值；或者去const转换后调用setSockAddrInet6 才可以。
```cpp
    ......
    auto sockaddr = addr.getSockAddr();
    auto sockaddr6 = sockets::sockaddr_in6_cast(sockaddr);
    const_cast<sockaddr_in6*>(sockaddr6)->sin6_scope_id = 2;
    sock.bindAddress(addr);
```

增加setScopeId后的写法：
```cpp
    ......
    addr.setScopeId(2);
    sock.bindAddress(addr);
```