### PR TITLE
fix link errors in enabling boost test

### DIFF
--- a/examples/sudoku/stat_unittest.cc
+++ b/examples/sudoku/stat_unittest.cc
@@ -5,7 +5,7 @@
 #include <boost/circular_buffer.hpp>
 #define BOOST_TEST_MAIN
 #define BOOST_TEST_DYN_LINK
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 using namespace muduo;
 

--- a/muduo/base/tests/LogStream_test.cc
+++ b/muduo/base/tests/LogStream_test.cc
@@ -6,7 +6,7 @@
 //#define BOOST_TEST_MODULE LogStreamTest
 #define BOOST_TEST_MAIN
 #define BOOST_TEST_DYN_LINK
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 using muduo::string;
 

--- a/muduo/net/http/tests/HttpRequest_unittest.cc
+++ b/muduo/net/http/tests/HttpRequest_unittest.cc
@@ -4,7 +4,7 @@
 //#define BOOST_TEST_MODULE BufferTest
 #define BOOST_TEST_MAIN
 #define BOOST_TEST_DYN_LINK
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 using muduo::string;
 using muduo::Timestamp;

--- a/muduo/net/tests/Buffer_unittest.cc
+++ b/muduo/net/tests/Buffer_unittest.cc
@@ -3,7 +3,7 @@
 //#define BOOST_TEST_MODULE BufferTest
 #define BOOST_TEST_MAIN
 #define BOOST_TEST_DYN_LINK
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 using muduo::string;
 using muduo::net::Buffer;

--- a/muduo/net/tests/InetAddress_unittest.cc
+++ b/muduo/net/tests/InetAddress_unittest.cc
@@ -5,7 +5,7 @@
 //#define BOOST_TEST_MODULE InetAddressTest
 #define BOOST_TEST_MAIN
 #define BOOST_TEST_DYN_LINK
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 using muduo::string;
 using muduo::net::InetAddress;

--- a/muduo/net/tests/ZlibStream_unittest.cc
+++ b/muduo/net/tests/ZlibStream_unittest.cc
@@ -4,7 +4,7 @@
 
 #define BOOST_TEST_MAIN
 #define BOOST_TEST_DYN_LINK
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 #include <stdio.h>
 


### PR DESCRIPTION
It seems that when enabling boost test with latest boost libs will result in link errors.
My boost is libboost1.58-dev
The errors are described as follows.

[100%] Linking CXX executable ../../bin/sudoku_stat_unittest
CMakeFiles/sudoku_stat_unittest.dir/stat_unittest.cc.o: In function `boost::unit_test::make_test_case(boost::function<void ()> const&, boost::unit_test::basic_cstring<char const>, boost::unit_test::basic_cstring<char const>, unsigned long)':
/usr/local/include/boost/test/tree/test_unit.hpp:249: undefined reference to `boost::unit_test::test_case::test_case(boost::unit_test::basic_cstring<char const>, boost::unit_test::basic_cstring<char const>, unsigned long, boost::function<void ()> const&)'
CMakeFiles/sudoku_stat_unittest.dir/stat_unittest.cc.o: In function `__static_initialization_and_destruction_0(int, int) [clone .constprop.102]':
/home/newplan/playground/networking/muduo/examples/sudoku/stat_unittest.cc:16: undefined reference to `boost::unit_test::ut_detail::auto_test_unit_registrar::auto_test_unit_registrar(boost::unit_test::test_case*, boost::unit_test::decorator::collector&, unsigned long)'
/home/newplan/playground/networking/muduo/examples/sudoku/stat_unittest.cc:31: undefined reference to `boost::unit_test::ut_detail::auto_test_unit_registrar::auto_test_unit_registrar(boost::unit_test::test_case*, boost::unit_test::decorator::collector&, unsigned long)'
/home/newplan/playground/networking/muduo/examples/sudoku/stat_unittest.cc:48: undefined reference to `boost::unit_test::ut_detail::auto_test_unit_registrar::auto_test_unit_registrar(boost::unit_test::test_case*, boost::unit_test::decorator::collector&, unsigned long)'
/home/newplan/playground/networking/muduo/examples/sudoku/stat_unittest.cc:66: undefined reference to `boost::unit_test::ut_detail::auto_test_unit_registrar::auto_test_unit_registrar(boost::unit_test::test_case*, boost::unit_test::decorator::collector&, unsigned long)'
/home/newplan/playground/networking/muduo/examples/sudoku/stat_unittest.cc:82: undefined reference to `boost::unit_test::ut_detail::auto_test_unit_registrar::auto_test_unit_registrar(boost::unit_test::test_case*, boost::unit_test::decorator::collector&, unsigned long)'
CMakeFiles/sudoku_stat_unittest.dir/stat_unittest.cc.o:/home/newplan/playground/networking/muduo/examples/sudoku/stat_unittest.cc:98: more undefined references to `boost::unit_test::ut_detail::auto_test_unit_registrar::auto_test_unit_registrar(boost::unit_test::test_case*, boost::unit_test::decorator::collector&, unsigned long)' follow
collect2: error: ld returned 1 exit status
examples/sudoku/CMakeFiles/sudoku_stat_unittest.dir/build.make:95: recipe for target 'bin/sudoku_stat_unittest' failed
make[2]: *** [bin/sudoku_stat_unittest] Error 1
CMakeFiles/Makefile2:5188: recipe for target 'examples/sudoku/CMakeFiles/sudoku_stat_unittest.dir/all' failed
make[1]: *** [examples/sudoku/CMakeFiles/sudoku_stat_unittest.dir/all] Error 2
Makefile:138: recipe for target 'all' failed
make: *** [all] Error 2