### PR TITLE
Fix move readable data in Buffer::makeSpace().

### DIFF
--- a/muduo/net/Buffer.cc
+++ b/muduo/net/Buffer.cc
@@ -56,3 +56,30 @@ ssize_t Buffer::readFd(int fd, int* savedErrno)
   return n;
 }
 
+void Buffer::prependAlign()
+{
+  size_t readable = readableBytes();
+  if (readerIndex_ == kCheapPrepend)
+  {
+    return;
+  }
+  else if (readerIndex_ < kCheapPrepend)
+  {
+    if (buffer_.size() < readable + kCheapPrepend)
+    {
+      buffer_.resize(readable+kCheapPrepend);
+    }
+    std::copy_backward(begin()+readerIndex_,
+                       begin()+writerIndex_,
+                       begin()+readable+kCheapPrepend);
+  }
+  else
+  {
+    std::copy(begin()+readerIndex_,
+              begin()+writerIndex_,
+              begin()+kCheapPrepend);
+  }
+  readerIndex_ = kCheapPrepend;
+  writerIndex_ = readerIndex_ + readable;
+  assert(readable == readableBytes());
+}

--- a/muduo/net/Buffer.h
+++ b/muduo/net/Buffer.h
@@ -389,24 +389,14 @@ class Buffer : public muduo::copyable
 
   void makeSpace(size_t len)
   {
-    if (writableBytes() + prependableBytes() < len + kCheapPrepend)
+    prependAlign();
+    if (writableBytes() < len)
     {
-      // FIXME: move readable data
       buffer_.resize(writerIndex_+len);
     }
-    else
-    {
-      // move readable data to the front, make space inside buffer
-      assert(kCheapPrepend < readerIndex_);
-      size_t readable = readableBytes();
-      std::copy(begin()+readerIndex_,
-                begin()+writerIndex_,
-                begin()+kCheapPrepend);
-      readerIndex_ = kCheapPrepend;
-      writerIndex_ = readerIndex_ + readable;
-      assert(readable == readableBytes());
-    }
   }
+
+  void prependAlign();
 
  private:
   std::vector<char> buffer_;

--- a/muduo/net/tests/Buffer_unittest.cc
+++ b/muduo/net/tests/Buffer_unittest.cc
@@ -56,11 +56,11 @@ BOOST_AUTO_TEST_CASE(testBufferGrow)
   buf.append(string(1000, 'z'));
   BOOST_CHECK_EQUAL(buf.readableBytes(), 1350);
   BOOST_CHECK_EQUAL(buf.writableBytes(), 0);
-  BOOST_CHECK_EQUAL(buf.prependableBytes(), Buffer::kCheapPrepend+50); // FIXME
+  BOOST_CHECK_EQUAL(buf.prependableBytes(), Buffer::kCheapPrepend);
 
   buf.retrieveAll();
   BOOST_CHECK_EQUAL(buf.readableBytes(), 0);
-  BOOST_CHECK_EQUAL(buf.writableBytes(), 1400); // FIXME
+  BOOST_CHECK_EQUAL(buf.writableBytes(), 1350);
   BOOST_CHECK_EQUAL(buf.prependableBytes(), Buffer::kCheapPrepend);
 }
 


### PR DESCRIPTION
每次调用makeSpace()时先调用prependAlign()使readerIndex_与kCheapPrepend对齐。
如果buffer_空间太小，会多一次resize()。