### PR TITLE
replace std::vector<char> with std::string in class Buffer

### DIFF
--- a/muduo/net/Buffer.h
+++ b/muduo/net/Buffer.h
@@ -18,7 +18,7 @@
 #include <muduo/net/Endian.h>
 
 #include <algorithm>
-#include <vector>
+#include <string>
 
 #include <assert.h>
 #include <string.h>
@@ -46,7 +46,7 @@ class Buffer : public muduo::copyable
   static const size_t kInitialSize = 1024;
 
   explicit Buffer(size_t initialSize = kInitialSize)
-    : buffer_(kCheapPrepend + initialSize),
+    : buffer_(kCheapPrepend + initialSize, 0),
       readerIndex_(kCheapPrepend),
       writerIndex_(kCheapPrepend)
   {
@@ -361,7 +361,7 @@ class Buffer : public muduo::copyable
 
   void shrink(size_t reserve)
   {
-    // FIXME: use vector::shrink_to_fit() in C++ 11 if possible.
+    // FIXME: use string::shrink_to_fit() in C++ 11 if possible.
     Buffer other;
     other.ensureWritableBytes(readableBytes()+reserve);
     other.append(toStringPiece());
@@ -409,7 +409,7 @@ class Buffer : public muduo::copyable
   }
 
  private:
-  std::vector<char> buffer_;
+  std::string buffer_;
   size_t readerIndex_;
   size_t writerIndex_;
 


### PR DESCRIPTION
using std::string to manage memory is much more effective than using  std::vector<char>

we test the resize function in the code as followed:

```#include <chrono>
#include <iostream>
#include <string>
#include <vector>

using namespace std;
using namespace chrono;

int main() {
  {
    auto start = system_clock::now();
    vector<char> vc;
    vc.resize(1024 * 1024);
    auto end = system_clock::now();
    auto duration = duration_cast<microseconds>(end - start);
    cout << "vector<char> cost"
         << double(duration.count()) * microseconds::period::num /
                microseconds::period::den
         << " seconds" << endl;
  }

  {
    auto start = system_clock::now();
    string s;
    s.resize(1024 * 1024);
    auto end = system_clock::now();
    auto duration = duration_cast<microseconds>(end - start);
    cout << "string       cost"
         << double(duration.count()) * microseconds::period::num /
                microseconds::period::den
         << " seconds" << endl;
  }

  return 0;
}
```
       
the output:
```
vector<char> cost0.000473 seconds
string       cost0.000278 seconds
```

the reason is that  vector<char> should call constructor for every char, but string needn't