### PR TITLE
fix: remove redundant std::move for a local object in a return statement

### DIFF
--- a/muduo/base/BlockingQueue.h
+++ b/muduo/base/BlockingQueue.h
@@ -52,7 +52,7 @@ class BlockingQueue : noncopyable
     assert(!queue_.empty());
     T front(std::move(queue_.front()));
     queue_.pop_front();
-    return std::move(front);
+    return front;
   }
 
   size_t size() const

--- a/muduo/base/BoundedBlockingQueue.h
+++ b/muduo/base/BoundedBlockingQueue.h
@@ -62,7 +62,7 @@ class BoundedBlockingQueue : noncopyable
     T front(std::move(queue_.front()));
     queue_.pop_front();
     notFull_.notify();
-    return std::move(front);
+    return front;
   }
 
   bool empty() const


### PR DESCRIPTION
fix #424 