### PR TITLE
fix a small 'build fail' issue caused by the deprecation of ByteSize() of protobuf message

### DIFF
--- a/examples/protobuf/codec/codec.cc
+++ b/examples/protobuf/codec/codec.cc
@@ -32,14 +32,14 @@ void ProtobufCodec::fillEmptyBuffer(Buffer* buf, const google::protobuf::Message
   // code copied from MessageLite::SerializeToArray() and MessageLite::SerializePartialToArray().
   GOOGLE_DCHECK(message.IsInitialized()) << InitializationErrorMessage("serialize", message);
 
-  int byte_size = message.ByteSize();
+  int byte_size = static_cast<int>(message.ByteSizeLong());
   buf->ensureWritableBytes(byte_size);
 
   uint8_t* start = reinterpret_cast<uint8_t*>(buf->beginWrite());
   uint8_t* end = message.SerializeWithCachedSizesToArray(start);
   if (end - start != byte_size)
   {
-    ByteSizeConsistencyError(byte_size, message.ByteSize(), static_cast<int>(end - start));
+    ByteSizeConsistencyError(byte_size, static_cast<int>(message.ByteSizeLong()), static_cast<int>(end - start));
   }
   buf->hasWritten(byte_size);
 

--- a/examples/protobuf/codec/codec.cc
+++ b/examples/protobuf/codec/codec.cc
@@ -32,14 +32,31 @@ void ProtobufCodec::fillEmptyBuffer(Buffer* buf, const google::protobuf::Message
   // code copied from MessageLite::SerializeToArray() and MessageLite::SerializePartialToArray().
   GOOGLE_DCHECK(message.IsInitialized()) << InitializationErrorMessage("serialize", message);
 
-  int byte_size = static_cast<int>(message.ByteSizeLong());
+  /**
+   * 'ByteSize()' of message is deprecated in Protocol Buffers v3.4.0 firstly. But, till to v3.11.0, it just getting start to be marked by '__attribute__((deprecated()))'.
+   * So, here, v3.9.2 is selected as maximum version using 'ByteSize()' to avoid potential effect for previous muduo code/projects as far as possible.
+   * Note: All information above just INFER from 
+   * 1) https://github.com/protocolbuffers/protobuf/releases/tag/v3.4.0
+   * 2) MACRO in file 'include/google/protobuf/port_def.inc'. eg. '#define PROTOBUF_DEPRECATED_MSG(msg) __attribute__((deprecated(msg)))'.
+   * In addition, usage of 'ToIntSize()' comes from Impl of ByteSize() in new version's Protocol Buffers.
+   */
+
+  #if GOOGLE_PROTOBUF_VERSION > 3009002
+    int byte_size = google::protobuf::internal::ToIntSize(message.ByteSizeLong());
+  #else
+    int byte_size = message.ByteSize();
+  #endif
   buf->ensureWritableBytes(byte_size);
 
   uint8_t* start = reinterpret_cast<uint8_t*>(buf->beginWrite());
   uint8_t* end = message.SerializeWithCachedSizesToArray(start);
   if (end - start != byte_size)
   {
-    ByteSizeConsistencyError(byte_size, static_cast<int>(message.ByteSizeLong()), static_cast<int>(end - start));
+    #if GOOGLE_PROTOBUF_VERSION > 3009002
+      ByteSizeConsistencyError(byte_size, google::protobuf::internal::ToIntSize(message.ByteSizeLong()), static_cast<int>(end - start));
+    #else
+      ByteSizeConsistencyError(byte_size, message.ByteSize(), static_cast<int>(end - start));
+    #endif
   }
   buf->hasWritten(byte_size);
 

--- a/muduo/net/protobuf/ProtobufCodecLite.cc
+++ b/muduo/net/protobuf/ProtobufCodecLite.cc
@@ -111,14 +111,31 @@ int ProtobufCodecLite::serializeToBuffer(const google::protobuf::Message& messag
   // code copied from MessageLite::SerializeToArray() and MessageLite::SerializePartialToArray().
   GOOGLE_DCHECK(message.IsInitialized()) << InitializationErrorMessage("serialize", message);
 
-  int byte_size = static_cast<int>(message.ByteSizeLong());
+  /**
+   * 'ByteSize()' of message is deprecated in Protocol Buffers v3.4.0 firstly. But, till to v3.11.0, it just getting start to be marked by '__attribute__((deprecated()))'.
+   * So, here, v3.9.2 is selected as maximum version using 'ByteSize()' to avoid potential effect for previous muduo code/projects as far as possible.
+   * Note: All information above just INFER from 
+   * 1) https://github.com/protocolbuffers/protobuf/releases/tag/v3.4.0
+   * 2) MACRO in file 'include/google/protobuf/port_def.inc'. eg. '#define PROTOBUF_DEPRECATED_MSG(msg) __attribute__((deprecated(msg)))'.
+   * In addition, usage of 'ToIntSize()' comes from Impl of ByteSize() in new version's Protocol Buffers.
+   */
+
+  #if GOOGLE_PROTOBUF_VERSION > 3009002
+    int byte_size = google::protobuf::internal::ToIntSize(message.ByteSizeLong());
+  #else
+    int byte_size = message.ByteSize();
+  #endif
   buf->ensureWritableBytes(byte_size + kChecksumLen);
 
   uint8_t* start = reinterpret_cast<uint8_t*>(buf->beginWrite());
   uint8_t* end = message.SerializeWithCachedSizesToArray(start);
   if (end - start != byte_size)
   {
-    ByteSizeConsistencyError(byte_size, static_cast<int>(message.ByteSizeLong()), static_cast<int>(end - start));
+    #if GOOGLE_PROTOBUF_VERSION > 3009002
+      ByteSizeConsistencyError(byte_size, google::protobuf::internal::ToIntSize(message.ByteSizeLong()), static_cast<int>(end - start));
+    #else
+      ByteSizeConsistencyError(byte_size, message.ByteSize(), static_cast<int>(end - start));
+    #endif
   }
   buf->hasWritten(byte_size);
   return byte_size;

--- a/muduo/net/protobuf/ProtobufCodecLite.cc
+++ b/muduo/net/protobuf/ProtobufCodecLite.cc
@@ -111,14 +111,14 @@ int ProtobufCodecLite::serializeToBuffer(const google::protobuf::Message& messag
   // code copied from MessageLite::SerializeToArray() and MessageLite::SerializePartialToArray().
   GOOGLE_DCHECK(message.IsInitialized()) << InitializationErrorMessage("serialize", message);
 
-  int byte_size = message.ByteSize();
+  int byte_size = static_cast<int>(message.ByteSizeLong());
   buf->ensureWritableBytes(byte_size + kChecksumLen);
 
   uint8_t* start = reinterpret_cast<uint8_t*>(buf->beginWrite());
   uint8_t* end = message.SerializeWithCachedSizesToArray(start);
   if (end - start != byte_size)
   {
-    ByteSizeConsistencyError(byte_size, message.ByteSize(), static_cast<int>(end - start));
+    ByteSizeConsistencyError(byte_size, static_cast<int>(message.ByteSizeLong()), static_cast<int>(end - start));
   }
   buf->hasWritten(byte_size);
   return byte_size;


### PR DESCRIPTION
Hi maintainers,
I use muduo/cpp17 and protobuf/cpp to do some personal projects recently. But build fail when compiling with lasted version's protobuf (3.11.2). I think the reason may be that '-Werror' parameter is enabled by default in muduo's make related files and ByteSize() API of protobuf message is deprecated in new version of protobuf, which will result in a warning in building. So there are some errors in building process. Although It is just a small issue, but I am still tried to fix it for fun. Thank you so much for your great works on muduo! : )

Details are list as following:
----------------------------------------START----------------------------------------------
Deprecation of ByteSize() may from protobuf 3.11.0
Ref:
line 578 at
https://github.com/protocolbuffers/protobuf/blob/master/CHANGES.txt
(de75651 on 21 Nov) 

Test platform: 
Ubuntu WSL in windows 10 1903
Protocol Buffers 3.11.2 / cpp

$gcc -v
Thread model: posix
gcc version 7.5.0 (Ubuntu 7.5.0-3ubuntu1~18.04)

$cat /proc/version
Linux version 4.4.0-18362-Microsoft (Microsoft@Microsoft.com) (gcc version 5.4.0 (GCC) ) #476-Microsoft Fri Nov 01 16:53:00 PST 2019

$lsb_release -a
No LSB modules are available.
Distributor ID: Ubuntu
Description:    Ubuntu 18.04.2 LTS
Release:        18.04
Codename:       bionic

Protocol Buffers Test Result:

PASS: protobuf-test
PASS: protobuf-lazy-descriptor-test
PASS: protobuf-lite-test
PASS: google/protobuf/compiler/zip_output_unittest.sh
PASS: protobuf-lite-arena-test
PASS: no-warning-test
Testsuite summary for Protocol Buffers 3.11.2
TOTAL: 6
PASS:  6
SKIP:  0
XFAIL: 0
FAIL:  0
XPASS: 0
ERROR: 0


Output of "./build.sh":
/home/***/temp/muduo/muduo/net/protobuf/ProtobufCodecLite.cc:114:36: error: ‘int google::protobuf::MessageLite::ByteSize() const’ is deprecated: Please use ByteSizeLong() instead [-Werror=deprecated-declarations]
   int byte_size = message.ByteSize();
                                    ^
In file included from /usr/local/include/google/protobuf/generated_enum_util.h:36:0,
                 from /usr/local/include/google/protobuf/generated_enum_reflection.h:44,
                 from /usr/local/include/google/protobuf/generated_message_reflection.h:48,
                 from /usr/local/include/google/protobuf/message.h:122,
                 from /home/***/temp/muduo/muduo/net/protorpc/google-inl.h:39,
                 from /home/***/temp/muduo/muduo/net/protobuf/ProtobufCodecLite.cc:15:
/usr/local/include/google/protobuf/message_lite.h:402:7: note: declared here
   int ByteSize() const { return internal::ToIntSize(ByteSizeLong()); }
       ^~~~~~~~
/home/***/temp/muduo/muduo/net/protobuf/ProtobufCodecLite.cc:121:58: error: ‘int google::protobuf::MessageLite::ByteSize() const’ is deprecated: Please use ByteSizeLong() instead [-Werror=deprecated-declarations]
     ByteSizeConsistencyError(byte_size, message.ByteSize(), static_cast<int>(end - start));
                                                          ^
In file included from /usr/local/include/google/protobuf/generated_enum_util.h:36:0,
                 from /usr/local/include/google/protobuf/generated_enum_reflection.h:44,
                 from /usr/local/include/google/protobuf/generated_message_reflection.h:48,
                 from /usr/local/include/google/protobuf/message.h:122,
                 from /home/***/temp/muduo/muduo/net/protorpc/google-inl.h:39,
                 from /home/***/temp/muduo/muduo/net/protobuf/ProtobufCodecLite.cc:15:
/usr/local/include/google/protobuf/message_lite.h:402:7: note: declared here
   int ByteSize() const { return internal::ToIntSize(ByteSizeLong()); }
       ^~~~~~~~
cc1plus: all warnings being treated as errors
muduo/net/protobuf/CMakeFiles/muduo_protobuf_codec.dir/build.make:62: recipe for target 'muduo/net/protobuf/CMakeFiles/muduo_protobuf_codec.dir/ProtobufCodecLite.cc.o' failed
make[2]: *** [muduo/net/protobuf/CMakeFiles/muduo_protobuf_codec.dir/ProtobufCodecLite.cc.o] Error 1
CMakeFiles/Makefile2:1776: recipe for target 'muduo/net/protobuf/CMakeFiles/muduo_protobuf_codec.dir/all' failed
make[1]: *** [muduo/net/protobuf/CMakeFiles/muduo_protobuf_codec.dir/all] Error 2
Makefile:140: recipe for target 'all' failed
make: *** [all] Error 2


/home/***/temp/muduo/examples/protobuf/codec/codec.cc: In static member function ‘static void ProtobufCodec::fillEmptyBuffer(muduo::net::Buffer*, const google::protobuf::Message&)’:
/home/***/temp/muduo/examples/protobuf/codec/codec.cc:35:36: error: ‘int google::protobuf::MessageLite::ByteSize() const’ is deprecated: Please use ByteSizeLong() instead [-Werror=deprecated-declarations]
   int byte_size = message.ByteSize();
                                    ^
In file included from /usr/local/include/google/protobuf/generated_enum_util.h:36:0,
                 from /usr/local/include/google/protobuf/generated_enum_reflection.h:44,
                 from /usr/local/include/google/protobuf/generated_message_reflection.h:48,
                 from /usr/local/include/google/protobuf/message.h:122,
                 from /home/***/temp/muduo/examples/protobuf/codec/codec.h:15,
                 from /home/***/temp/muduo/examples/protobuf/codec/codec.cc:9:
/usr/local/include/google/protobuf/message_lite.h:402:7: note: declared here
   int ByteSize() const { return internal::ToIntSize(ByteSizeLong()); }
       ^~~~~~~~
/home/***/temp/muduo/examples/protobuf/codec/codec.cc:42:58: error: ‘int google::protobuf::MessageLite::ByteSize() const’ is deprecated: Please use ByteSizeLong() instead [-Werror=deprecated-declarations]
     ByteSizeConsistencyError(byte_size, message.ByteSize(), static_cast<int>(end - start));
                                                          ^
In file included from /usr/local/include/google/protobuf/generated_enum_util.h:36:0,
                 from /usr/local/include/google/protobuf/generated_enum_reflection.h:44,
                 from /usr/local/include/google/protobuf/generated_message_reflection.h:48,
                 from /usr/local/include/google/protobuf/message.h:122,
                 from /home/***/temp/muduo/examples/protobuf/codec/codec.h:15,
                 from /home/***/temp/muduo/examples/protobuf/codec/codec.cc:9:
/usr/local/include/google/protobuf/message_lite.h:402:7: note: declared here
   int ByteSize() const { return internal::ToIntSize(ByteSizeLong()); }
       ^~~~~~~~
cc1plus: all warnings being treated as errors
examples/protobuf/codec/CMakeFiles/protobuf_codec.dir/build.make:62: recipe for target 'examples/protobuf/codec/CMakeFiles/protobuf_codec.dir/codec.cc.o' failed
make[2]: *** [examples/protobuf/codec/CMakeFiles/protobuf_codec.dir/codec.cc.o] Error 1
CMakeFiles/Makefile2:5557: recipe for target 'examples/protobuf/codec/CMakeFiles/protobuf_codec.dir/all' failed
make[1]: *** [examples/protobuf/codec/CMakeFiles/protobuf_codec.dir/all] Error 2
Makefile:140: recipe for target 'all' failed
make: *** [all] Error 2

---------------------------------------END-----------------------------------------------