### PR TITLE
Fix deprecated API in Boost.asio

### DIFF
--- a/examples/ace/ttcp/ttcp_asio_async.cc
+++ b/examples/ace/ttcp/ttcp_asio_async.cc
@@ -21,8 +21,13 @@ class TtcpServerConnection : public std::enable_shared_from_this<TtcpServerConne
                              muduo::noncopyable
 {
  public:
+#if BOOST_VERSION < 107000L
+  TtcpServerConnection(boost::asio::io_service& io_service)
+    : socket_(io_service), count_(0), payload_(NULL), ack_(0)
+#else
   TtcpServerConnection(const boost::asio::executor& executor)
     : socket_(executor), count_(0), payload_(NULL), ack_(0)
+#endif
   {
     sessionMessage_.number = 0;
     sessionMessage_.length = 0;
@@ -143,8 +148,12 @@ typedef std::shared_ptr<TtcpServerConnection> TtcpServerConnectionPtr;
 
 void doAccept(tcp::acceptor& acceptor)
 {
+#if BOOST_VERSION < 107000L
   // no need to pre-create new_connection if we use asio 1.12 or boost 1.66+
+  TtcpServerConnectionPtr new_connection(new TtcpServerConnection(acceptor.get_io_service()));
+#else
   TtcpServerConnectionPtr new_connection(new TtcpServerConnection(acceptor.get_executor()));
+#endif
   acceptor.async_accept(
       new_connection->socket(),
       [&acceptor, new_connection](boost::system::error_code error)  // move new_connection in C++14

--- a/examples/ace/ttcp/ttcp_asio_async.cc
+++ b/examples/ace/ttcp/ttcp_asio_async.cc
@@ -21,8 +21,8 @@ class TtcpServerConnection : public std::enable_shared_from_this<TtcpServerConne
                              muduo::noncopyable
 {
  public:
-  TtcpServerConnection(boost::asio::io_service& io_service)
-    : socket_(io_service), count_(0), payload_(NULL), ack_(0)
+  TtcpServerConnection(boost::asio::executor executor)
+    : socket_(executor), count_(0), payload_(NULL), ack_(0)
   {
     sessionMessage_.number = 0;
     sessionMessage_.length = 0;
@@ -144,7 +144,7 @@ typedef std::shared_ptr<TtcpServerConnection> TtcpServerConnectionPtr;
 void doAccept(tcp::acceptor& acceptor)
 {
   // no need to pre-create new_connection if we use asio 1.12 or boost 1.66+
-  TtcpServerConnectionPtr new_connection(new TtcpServerConnection(acceptor.get_io_service()));
+  TtcpServerConnectionPtr new_connection(new TtcpServerConnection(acceptor.get_executor()));
   acceptor.async_accept(
       new_connection->socket(),
       [&acceptor, new_connection](boost::system::error_code error)  // move new_connection in C++14

--- a/examples/ace/ttcp/ttcp_asio_async.cc
+++ b/examples/ace/ttcp/ttcp_asio_async.cc
@@ -21,7 +21,7 @@ class TtcpServerConnection : public std::enable_shared_from_this<TtcpServerConne
                              muduo::noncopyable
 {
  public:
-  TtcpServerConnection(boost::asio::executor executor)
+  TtcpServerConnection(const boost::asio::executor& executor)
     : socket_(executor), count_(0), payload_(NULL), ack_(0)
   {
     sessionMessage_.number = 0;


### PR DESCRIPTION
`get_io_service` is marked as deprecated for a long time. Since Boost 1.70, it is removed. So with the latest version Boost, it will cause build fail.
According to the release notes, fix the deprecated API, and confirmed with Boost 1.72.