### PR TITLE
Add body field for HttpRequest

### DIFF
--- a/muduo/net/http/HttpContext.cc
+++ b/muduo/net/http/HttpContext.cc
@@ -98,9 +98,16 @@ bool HttpContext::parseRequest(Buffer* buf, Timestamp receiveTime)
         else
         {
           // empty line, end of header
-          // FIXME:
-          state_ = kGotAll;
-          hasMore = false;
+          // FIXME: can other http method contain a body?
+          if (request_.method() == kGet)
+          {
+            state_ = kGotAll;
+            hasMore = false;
+          }
+          else if (request_.method() == kPost)
+          {
+            state_ = kExpectBody;
+          }
         }
         buf->retrieveUntil(crlf + 2);
       }
@@ -111,7 +118,13 @@ bool HttpContext::parseRequest(Buffer* buf, Timestamp receiveTime)
     }
     else if (state_ == kExpectBody)
     {
-      // FIXME:
+      // FIXME: can other http method contain a body?
+      if (request_.method() == kPost)
+      {
+        request_.setBody(buf->retrieveAllAsString());
+        state_ = kGotAll;
+        hasMore = false;
+      }
     }
   }
   return ok;

--- a/muduo/net/http/HttpRequest.h
+++ b/muduo/net/http/HttpRequest.h
@@ -162,6 +162,12 @@ class HttpRequest : public muduo::copyable
   const std::map<string, string>& headers() const
   { return headers_; }
 
+  void setBody(string content)
+  { body_ = content; }
+
+  const string& getBody() const 
+  { return body_; }
+
   void swap(HttpRequest& that)
   {
     std::swap(method_, that.method_);
@@ -177,6 +183,7 @@ class HttpRequest : public muduo::copyable
   Version version_;
   string path_;
   string query_;
+  string body_;
   Timestamp receiveTime_;
   std::map<string, string> headers_;
 };


### PR DESCRIPTION
Add body field for HttpRequest, but only support the POST method, not support the GET method.