### PR TITLE
Solve the problem that the bound object has been destroyed during callback for TcpClient

### DIFF
--- a/muduo/net/CMakeLists.txt
+++ b/muduo/net/CMakeLists.txt
@@ -27,7 +27,7 @@ set(net_SRCS
   TimerQueue.cc
   )
 
-add_library(muduo_net SHARED ${net_SRCS})
+add_library(muduo_net ${net_SRCS})
 target_link_libraries(muduo_net muduo_base)
 
 #add_library(muduo_net_cpp11 ${net_SRCS})

--- a/muduo/net/CMakeLists.txt
+++ b/muduo/net/CMakeLists.txt
@@ -27,7 +27,7 @@ set(net_SRCS
   TimerQueue.cc
   )
 
-add_library(muduo_net ${net_SRCS})
+add_library(muduo_net SHARED ${net_SRCS})
 target_link_libraries(muduo_net muduo_base)
 
 #add_library(muduo_net_cpp11 ${net_SRCS})

--- a/muduo/net/Connector.h
+++ b/muduo/net/Connector.h
@@ -16,7 +16,7 @@
 
 #include <functional>
 #include <memory>
-
+#define _USE_SMART_POINTER_
 namespace muduo
 {
 namespace net
@@ -28,10 +28,18 @@ class EventLoop;
 class Connector : noncopyable,
                   public std::enable_shared_from_this<Connector>
 {
+
+#ifdef _USE_SMART_POINTER_
+protected:
+    Connector(EventLoop* loop, const InetAddress& serverAddr);
+#endif
  public:
   typedef std::function<void (int sockfd)> NewConnectionCallback;
-
+#ifndef _USE_SMART_POINTER_
   Connector(EventLoop* loop, const InetAddress& serverAddr);
+#else
+    static std::shared_ptr<Connector> create(EventLoop* loop, const InetAddress& serverAddr);
+#endif
   ~Connector();
 
   void setNewConnectionCallback(const NewConnectionCallback& cb)

--- a/muduo/net/TcpClient.cc
+++ b/muduo/net/TcpClient.cc
@@ -55,7 +55,11 @@ TcpClient::TcpClient(EventLoop* loop,
                      const InetAddress& serverAddr,
                      const string& nameArg)
   : loop_(CHECK_NOTNULL(loop)),
+    #ifndef _USE_SMART_POINTER_
     connector_(new Connector(loop, serverAddr)),
+    #else
+    connector_(Connector::create(loop,serverAddr)),
+    #endif
     name_(nameArg),
     connectionCallback_(defaultConnectionCallback),
     messageCallback_(defaultMessageCallback),


### PR DESCRIPTION
之前回复过大神，我现在有一些想法，关于TcpClient销毁，但是回调仍然依赖于这个对象或者子对象，我这里在回调部分，全都使用了智能指针，并且将Connector的构造函数隐藏，只能使用Connector::create来创造智能指针对象，避免使用者，在使用过程中，在栈中构造Connector,在我的工程代码环境中测试过，没有出现之前提到的由于对象销毁，回调时依赖于无效的指针的问题,大神可以看看，这样改行不行