### PR TITLE
Update build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -8,7 +8,7 @@ BUILD_TYPE=${BUILD_TYPE:-release}
 INSTALL_DIR=${INSTALL_DIR:-../${BUILD_TYPE}-install-cpp17}
 CXX=${CXX:-g++}
 
-ln -sf $BUILD_DIR/$BUILD_TYPE-cpp11/compile_commands.json
+ln -sf $BUILD_DIR/$BUILD_TYPE-cpp17/compile_commands.json
 
 mkdir -p $BUILD_DIR/$BUILD_TYPE-cpp17 \
   && cd $BUILD_DIR/$BUILD_TYPE-cpp17 \


### PR DESCRIPTION
Fix a small typo for creating soft link to compile_commands.json.

The build.sh script in `cpp-17` branch creates a soft-link to a cpp-11 build dir, which looks like a typo.