### PR TITLE
fix corner case : happens before issue

### DIFF
--- a/muduo/net/EventLoop.cc
+++ b/muduo/net/EventLoop.cc
@@ -112,6 +112,7 @@ void EventLoop::loop()
   {
     activeChannels_.clear();
     pollReturnTime_ = poller_->poll(kPollTimeMs, &activeChannels_);
+    callingPendingFunctors_ = false;
     ++iteration_;
     if (Logger::logLevel() <= Logger::TRACE)
     {
@@ -254,18 +255,17 @@ void EventLoop::handleRead()
 void EventLoop::doPendingFunctors()
 {
   std::vector<Functor> functors;
-  callingPendingFunctors_ = true;
 
   {
   MutexLockGuard lock(mutex_);
   functors.swap(pendingFunctors_);
+  callingPendingFunctors_ = true;
   }
 
   for (const Functor& functor : functors)
   {
     functor();
   }
-  callingPendingFunctors_ = false;
 }
 
 void EventLoop::printActiveChannels() const

--- a/muduo/net/EventLoop.h
+++ b/muduo/net/EventLoop.h
@@ -140,7 +140,7 @@ class EventLoop : noncopyable
   bool looping_; /* atomic */
   std::atomic<bool> quit_;
   bool eventHandling_; /* atomic */
-  bool callingPendingFunctors_; /* atomic */
+  std::atomic<bool>callingPendingFunctors_; /* atomic */
   int64_t iteration_;
   const pid_t threadId_;
   Timestamp pollReturnTime_;


### PR DESCRIPTION
consider the corner case, it will starve if there is no poll event.
```
EventLoop::loop()
{
  while(!quit_)
  {
     poller_->poll();    
     ...
     doPendingFunctors();         //  callingPendingFunctors_ is false
     
     otherThread->queueInLoop(Functor);    // won't call wakeup
  }
}
```