### PR TITLE
fixbug: Channel memory leak

### DIFF
--- a/muduo/net/TcpConnection.cc
+++ b/muduo/net/TcpConnection.cc
@@ -342,6 +342,7 @@ void TcpConnection::connectDestroyed()
     connectionCallback_(shared_from_this());
   }
   channel_->remove();
+  delete channel_;
 }
 
 void TcpConnection::handleRead(Timestamp receiveTime)


### PR DESCRIPTION
Hi,
  I found that there is no 'delete' corresponding to the 'new Channel', and this will prevent the dtor of TcpConnection from being called (for there is a tied object in the class Channel). 
  I have added a delete statement in function 'TcpConnection::connectDestroyed' because it is the last function called before the dtor of TcpConnection. And we can't add the delete statement in the dtor of TcpConnection because it won't be called (reason in the above).
Hope that's helpful.
  