### PR TITLE
bugfix: Channel memory leak

### DIFF
--- a/muduo/net/TcpConnection.cc
+++ b/muduo/net/TcpConnection.cc
@@ -69,6 +69,7 @@ TcpConnection::~TcpConnection()
             << " fd=" << channel_->fd()
             << " state=" << stateToString();
   assert(state_ == kDisconnected);
+  delete channel_;
 }
 
 bool TcpConnection::getTcpInfo(struct tcp_info* tcpi) const


### PR DESCRIPTION
There is no 'delete'  corresponding to the 'new Channel'.