### PR TITLE
fix THRIFT_OVERLOAD_IF error

### DIFF
--- a/contrib/thrift/ThriftServer.h
+++ b/contrib/thrift/ThriftServer.h
@@ -23,12 +23,10 @@ class ThriftServer : boost::noncopyable,
                      public TServer
 {
  public:
-  template <typename ProcessorFactory>
-  ThriftServer(const boost::shared_ptr<ProcessorFactory>& processorFactory,
+  ThriftServer(const boost::shared_ptr<TProcessorFactory>& processorFactory,
                muduo::net::EventLoop* eventloop,
                const muduo::net::InetAddress& addr,
-               const muduo::string& name,
-               THRIFT_OVERLOAD_IF(ProcessorFactory, TProcessorFactory))
+               const muduo::string& name)
     : TServer(processorFactory),
       server_(eventloop, addr, name),
       numWorkerThreads_(0),
@@ -38,12 +36,10 @@ class ThriftServer : boost::noncopyable,
                                               this, muduo::_1));
   }
 
-  template <typename Processor>
-  ThriftServer(const boost::shared_ptr<Processor>& processor,
+  ThriftServer(const boost::shared_ptr<TProcessor>& processor,
                muduo::net::EventLoop* eventloop,
                const muduo::net::InetAddress& addr,
-               const muduo::string& name,
-               THRIFT_OVERLOAD_IF(Processor, TProcessor))
+               const muduo::string& name)
     : TServer(processor),
       server_(eventloop, addr, name),
       numWorkerThreads_(0),
@@ -53,13 +49,11 @@ class ThriftServer : boost::noncopyable,
                                               this, muduo::_1));
   }
 
-  template <typename ProcessorFactory>
-  ThriftServer(const boost::shared_ptr<ProcessorFactory>& processorFactory,
+  ThriftServer(const boost::shared_ptr<TProcessorFactory>& processorFactory,
                const boost::shared_ptr<TProtocolFactory>& protocolFactory,
                muduo::net::EventLoop* eventloop,
                const muduo::net::InetAddress& addr,
-               const muduo::string& name,
-               THRIFT_OVERLOAD_IF(ProcessorFactory, TProcessorFactory))
+               const muduo::string& name)
     : TServer(processorFactory),
       server_(eventloop, addr, name),
       numWorkerThreads_(0),
@@ -71,13 +65,11 @@ class ThriftServer : boost::noncopyable,
     setOutputProtocolFactory(protocolFactory);
   }
 
-  template <typename Processor>
-  ThriftServer(const boost::shared_ptr<Processor>& processor,
+  ThriftServer(const boost::shared_ptr<TProcessor>& processor,
                const boost::shared_ptr<TProtocolFactory>& protocolFactory,
                muduo::net::EventLoop* eventloop,
                const muduo::net::InetAddress& addr,
-               const muduo::string& name,
-               THRIFT_OVERLOAD_IF(Processor, TProcessor))
+               const muduo::string& name)
     : TServer(processor),
       server_(eventloop, addr, name),
       numWorkerThreads_(0),
@@ -89,14 +81,12 @@ class ThriftServer : boost::noncopyable,
     setOutputProtocolFactory(protocolFactory);
   }
 
-  template <typename ProcessorFactory>
-  ThriftServer(const boost::shared_ptr<ProcessorFactory>& processorFactory,
+  ThriftServer(const boost::shared_ptr<TProcessorFactory>& processorFactory,
                const boost::shared_ptr<TTransportFactory>& transportFactory,
                const boost::shared_ptr<TProtocolFactory>& protocolFactory,
                muduo::net::EventLoop* eventloop,
                const muduo::net::InetAddress& addr,
-               const muduo::string& name,
-               THRIFT_OVERLOAD_IF(ProcessorFactory, TProcessorFactory))
+               const muduo::string& name)
     : TServer(processorFactory),
       server_(eventloop, addr, name),
       numWorkerThreads_(0),
@@ -110,14 +100,12 @@ class ThriftServer : boost::noncopyable,
     setOutputProtocolFactory(protocolFactory);
   }
 
-  template <typename Processor>
-  ThriftServer(const boost::shared_ptr<Processor>& processor,
+  ThriftServer(const boost::shared_ptr<TProcessor>& processor,
                const boost::shared_ptr<TTransportFactory>& transportFactory,
                const boost::shared_ptr<TProtocolFactory>& protocolFactory,
                muduo::net::EventLoop* eventloop,
                const muduo::net::InetAddress& addr,
-               const muduo::string& name,
-               THRIFT_OVERLOAD_IF(Processor, TProcessor))
+               const muduo::string& name)
     : TServer(processor),
       server_(eventloop, addr, name),
       numWorkerThreads_(0),
@@ -131,16 +119,14 @@ class ThriftServer : boost::noncopyable,
     setOutputProtocolFactory(protocolFactory);
   }
 
-  template <typename ProcessorFactory>
-  ThriftServer(const boost::shared_ptr<ProcessorFactory>& processorFactory,
+  ThriftServer(const boost::shared_ptr<TProcessorFactory>& processorFactory,
                const boost::shared_ptr<TTransportFactory>& inputTransportFactory,
                const boost::shared_ptr<TTransportFactory>& outputTransportFactory,
                const boost::shared_ptr<TProtocolFactory>& inputProtocolFactory,
                const boost::shared_ptr<TProtocolFactory>& outputProtocolFactory,
                muduo::net::EventLoop* eventloop,
                const muduo::net::InetAddress& addr,
-               const muduo::string& name,
-               THRIFT_OVERLOAD_IF(ProcessorFactory, TProcessorFactory))
+               const muduo::string& name)
     : TServer(processorFactory),
       server_(eventloop, addr, name),
       numWorkerThreads_(0),
@@ -154,16 +140,14 @@ class ThriftServer : boost::noncopyable,
     setOutputProtocolFactory(outputProtocolFactory);
   }
 
-  template <typename Processor>
-  ThriftServer(const boost::shared_ptr<Processor>& processor,
+  ThriftServer(const boost::shared_ptr<TProcessor>& processor,
                const boost::shared_ptr<TTransportFactory>& inputTransportFactory,
                const boost::shared_ptr<TTransportFactory>& outputTransportFactory,
                const boost::shared_ptr<TProtocolFactory>& inputProtocolFactory,
                const boost::shared_ptr<TProtocolFactory>& outputProtocolFactory,
                muduo::net::EventLoop* eventloop,
                const muduo::net::InetAddress& addr,
-               const muduo::string& name,
-               THRIFT_OVERLOAD_IF(Processor, TProcessor))
+               const muduo::string& name)
     : TServer(processor),
       server_(eventloop, addr, name),
       numWorkerThreads_(0),


### PR DESCRIPTION
"THRIFT_OVERLOAD_IF has not been declared " compile error with 0.11.0 thrift,  remove old style,  tested with thrift 0.11.0