### PR TITLE
Fix compilation error on Mac

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,9 +86,5 @@ add_subdirectory(muduo/net)
 
 if(NOT CMAKE_BUILD_NO_EXAMPLES)
   add_subdirectory(examples)
-else()
-  if(CARES_INCLUDE_DIR AND CARES_LIBRARY)
-    add_subdirectory(examples/cdns)
-  endif()
 endif()
 

--- a/muduo/base/AsyncLogging.h
+++ b/muduo/base/AsyncLogging.h
@@ -6,13 +6,9 @@
 #include <muduo/base/CountDownLatch.h>
 #include <muduo/base/Mutex.h>
 #include <muduo/base/Thread.h>
-
 #include <muduo/base/LogStream.h>
 
-#include <boost/bind.hpp>
 #include <boost/noncopyable.hpp>
-#include <boost/scoped_ptr.hpp>
-#include <boost/ptr_container/ptr_vector.hpp>
 
 namespace muduo
 {
@@ -52,14 +48,14 @@ class AsyncLogging : boost::noncopyable
  private:
 
   // declare but not define, prevent compiler-synthesized functions
-  AsyncLogging(const AsyncLogging&);  // ptr_container
-  void operator=(const AsyncLogging&);  // ptr_container
+  AsyncLogging(const AsyncLogging&);
+  void operator=(const AsyncLogging&);
 
   void threadFunc();
 
   typedef muduo::detail::FixedBuffer<muduo::detail::kLargeBuffer> Buffer;
-  typedef boost::ptr_vector<Buffer> BufferVector;
-  typedef BufferVector::auto_type BufferPtr;
+  typedef std::unique_ptr<Buffer> BufferPtr;
+  typedef std::vector<BufferPtr> BufferVector;
 
   const int flushInterval_;
   bool running_;


### PR DESCRIPTION
1. Replace boost pointer container with std container in AsyncLogging( `std::vector<std::unique_ptr<T>>` actually).
2. When  CMAKE_BUILD_NO_EXAMPLES=ON, we shouldn't build cdns(I think), since it's under example directory.