### PR TITLE
fix bug：std::vector初始化后再emplace导致vector大小翻倍的问题

### DIFF
--- a/muduo/base/tests/BoundedBlockingQueue_test.cc
+++ b/muduo/base/tests/BoundedBlockingQueue_test.cc
@@ -20,8 +20,8 @@ class Test
     {
       char name[32];
       snprintf(name, sizeof name, "work thread %d", i);
-      threads_.emplace_back(new muduo::Thread(
-            std::bind(&Test::threadFunc, this), muduo::string(name)));
+      threads_[i] = std::make_unique<muduo::Thread>(std::bind(&Test::threadFunc, this),
+                                     muduo::string(name));
     }
     for (auto& thr : threads_)
     {


### PR DESCRIPTION
cpp17 分支中的muduo/base/tests/BoundedBlockingQueue_test.cc 在运行时会直接core dump，考虑是vector在构造函数指定了大小后，又进行emplace操作，这会使vector大小翻倍，且初始化的内容全为空，后面线程在运行时就会core dump。