### PR TITLE
fix: callback of expired timer

### DIFF
--- a/muduo/net/TimerQueue.cc
+++ b/muduo/net/TimerQueue.cc
@@ -173,7 +173,11 @@ void TimerQueue::handleRead()
   // safe to callback outside critical section
   for (const Entry& it : expired)
   {
-    it.second->run();
+    ActiveTimer timer(it.second, it.second->sequence());
+    if (cancelingTimers_.find(timer) == cancelingTimers_.end())
+    {
+      it.second->run();
+    }
   }
   callingExpiredTimers_ = false;
 


### PR DESCRIPTION
Callback of expired timer should not be called if it has been cancelled by another expired timer. 

#668 