### PR TITLE
修复全局变量初始化顺序问题

### DIFF
--- a/muduo/base/Logging.cc
+++ b/muduo/base/Logging.cc
@@ -54,7 +54,16 @@ Logger::LogLevel initLogLevel()
     return Logger::INFO;
 }
 
-Logger::LogLevel g_logLevel = initLogLevel();
+// Logger::LogLevel g_logLevel = initLogLevel();
+static Logger::LogLevel& g_logLevel()
+{
+  static Logger::LogLevel g_logLevel = initLogLevel();
+  return g_logLevel;
+}
+Logger::LogLevel Logger::logLevel()
+{
+  return g_logLevel();
+}
 
 const char* LogLevelName[Logger::NUM_LOG_LEVELS] =
 {
@@ -207,7 +216,7 @@ Logger::~Logger()
 
 void Logger::setLogLevel(Logger::LogLevel level)
 {
-  g_logLevel = level;
+  g_logLevel() = level;
 }
 
 void Logger::setOutput(OutputFunc out)

--- a/muduo/base/Logging.h
+++ b/muduo/base/Logging.h
@@ -70,7 +70,7 @@ class Logger
 
   static LogLevel logLevel();
   static void setLogLevel(LogLevel level);
-
+  
   typedef void (*OutputFunc)(const char* msg, int len);
   typedef void (*FlushFunc)();
   static void setOutput(OutputFunc);
@@ -98,12 +98,6 @@ class Impl
 
 };
 
-extern Logger::LogLevel g_logLevel;
-
-inline Logger::LogLevel Logger::logLevel()
-{
-  return g_logLevel;
-}
 
 //
 // CAUTION: do not write:


### PR DESCRIPTION
就是**main**函数之前的默认日志等级不明确的问题。是不同编译单元之间的**全局变量初始化**顺序不明确导致的
第一次提交pr，不太会用，我把示例演示放到了下面的链接里
[commit](https://github.com/chenshuo/muduo/commit/f18cda20503a010dc3a2daf539f80fc8ab12917e#commitcomment-133661997)