### PR TITLE
消除void TcpConnection::send(Buffer* buf)中buf的copy

### DIFF
--- a/muduo/net/TcpConnection.cc
+++ b/muduo/net/TcpConnection.cc
@@ -121,12 +121,10 @@ void TcpConnection::send(Buffer* buf)
     }
     else
     {
-      void (TcpConnection::*fp)(const StringPiece& message) = &TcpConnection::sendInLoop;
-      loop_->runInLoop(
-          std::bind(fp,
-                    this,     // FIXME
-                    buf->retrieveAllAsString()));
-                    //std::forward<string>(message)));
+      auto temp = std::make_shared<Buffer>(std::move(*buf));// move
+      loop_->queueInLoop([this,temp](){//copy temp(ptr)
+        this->sendInLoop(temp->peek(),temp->readableBytes());//转到loop_
+      });
     }
   }
 }


### PR DESCRIPTION
消除`void TcpConnection::send(Buffer* buf)`中buf的**copy**

`retrieveAllAsString`函数会生成一个临时的**string**，造成内存**copy**，使用`std::move`消除内存拷贝