### PR TITLE
Optimize: support for single log message bigger than muduo::detail::kLargeBuffer

### DIFF
--- a/muduo/base/AsyncLogging.cc
+++ b/muduo/base/AsyncLogging.cc
@@ -33,26 +33,12 @@ AsyncLogging::AsyncLogging(const string& basename,
 
 void AsyncLogging::append(const char* logline, int len)
 {
+  if (!running_)
+  {
+      return;
+  }
   muduo::MutexLockGuard lock(mutex_);
-  if (currentBuffer_->avail() > len)
-  {
-    currentBuffer_->append(logline, len);
-  }
-  else
-  {
-    buffers_.push_back(std::move(currentBuffer_));
-
-    if (nextBuffer_)
-    {
-      currentBuffer_ = std::move(nextBuffer_);
-    }
-    else
-    {
-      currentBuffer_.reset(new Buffer); // Rarely happens
-    }
-    currentBuffer_->append(logline, len);
-    cond_.notify();
-  }
+  append_unlocked(logline, len);
 }
 
 void AsyncLogging::threadFunc()
@@ -134,3 +120,32 @@ void AsyncLogging::threadFunc()
   output.flush();
 }
 
+void AsyncLogging::append_unlocked(const char* buf, int len)
+{
+  mutex_.assertLocked();
+  while (len > kBufferSize)
+  {
+      append_unlocked(buf, kBufferSize);
+      buf += kBufferSize;
+      len -= kBufferSize;
+  }
+  if (currentBuffer_->avail() > len)
+  {
+    currentBuffer_->append(buf, len);
+  }
+  else
+  {
+    buffers_.push_back(std::move(currentBuffer_));
+
+    if (nextBuffer_)
+    {
+      currentBuffer_ = std::move(nextBuffer_);
+    }
+    else
+    {
+      currentBuffer_.reset(new Buffer); // Rarely happens
+    }
+    currentBuffer_->append(buf, len);
+    cond_.notify();
+  }
+}

--- a/muduo/base/AsyncLogging.h
+++ b/muduo/base/AsyncLogging.h
@@ -54,8 +54,10 @@ class AsyncLogging : noncopyable
  private:
 
   void threadFunc();
+  void append_unlocked(const char* buf, int len) REQUIRES(mutex_);
 
-  typedef muduo::detail::FixedBuffer<muduo::detail::kLargeBuffer> Buffer;
+  static const int kBufferSize = muduo::detail::kLargeBuffer;
+  typedef muduo::detail::FixedBuffer<kBufferSize> Buffer;
   typedef std::vector<std::unique_ptr<Buffer>> BufferVector;
   typedef BufferVector::value_type BufferPtr;
 


### PR DESCRIPTION
AsyncLoggin单条日志的大小受到muduo::detail::kLargeBuffer的限制，超过此大小的日志写不进去