### PR TITLE
fix build branch cpp17 on Kunpeng-920 where std::numeric_limits<long double>::digits10 == 33, instead of 18 on aarch64.

### DIFF
--- a/muduo/base/LogStream.h
+++ b/muduo/base/LogStream.h
@@ -165,7 +165,7 @@ class LogStream : noncopyable
 
   Buffer buffer_;
 
-  static const int kMaxNumericSize = 32;
+  static const int kMaxNumericSize = 48;
 };
 
 class Fmt // : noncopyable


### PR DESCRIPTION
Build branch cpp17 fail on aarch64, reproduce step:
* build enviroment:
```
[root@ecs-2bfc ~]# cat /etc/os-release 
NAME="openEuler"
VERSION="20.03 (LTS)"
ID="openEuler"
VERSION_ID="20.03"
PRETTY_NAME="openEuler 20.03 (LTS)"
ANSI_COLOR="0;31"

[root@ecs-2bfc ~]# uname -a
Linux ecs-2bfc 4.19.90-2110.8.0.0119.oe1.aarch64 #1 SMP Wed Oct 27 10:35:51 UTC 2021 aarch64 aarch64 aarch64 GNU/Linux
[root@ecs-2bfc ~]# lscpu
Architecture:                    aarch64
CPU op-mode(s):                  64-bit
Byte Order:                      Little Endian
CPU(s):                          2
On-line CPU(s) list:             0,1
Thread(s) per core:              1
Core(s) per socket:              2
Socket(s):                       1
NUMA node(s):                    1
Vendor ID:                       HiSilicon
Model:                           0
Model name:                      Kunpeng-920
Stepping:                        0x1
CPU max MHz:                     2400.0000
CPU min MHz:                     2400.0000
BogoMIPS:                        200.00
L1d cache:                       128 KiB
L1i cache:                       128 KiB
L2 cache:                        1 MiB
L3 cache:                        32 MiB
NUMA node0 CPU(s):               0,1
Vulnerability Itlb multihit:     Not affected
Vulnerability L1tf:              Not affected
Vulnerability Mds:               Not affected
Vulnerability Meltdown:          Not affected
Vulnerability Spec store bypass: Not affected
Vulnerability Spectre v1:        Mitigation; __user pointer sanitization
Vulnerability Spectre v2:        Not affected
Vulnerability Srbds:             Not affected
Vulnerability Tsx async abort:   Not affected
Flags:                           fp asimd evtstrm aes pmull sha1 sha2 crc32 atomics fphp asimdhp cpuid asimdrdm jscvt fcma dcpop asimddp asimdfhm
[root@ecs-2bfc ~]# 
```
* install the necessary software
```
yum install wget git gcc gcc-c++ make -y
wget -O cmake-3.25.2.tar.gz "https://github.com/Kitware/CMake/releases/download/v3.25.2/cmake-3.25.2-linux-aarch64.tar.gz"
tar -zxf cmake-3.25.2.tar.gz
export PATH="$PATH:/root/cmake-3.25.2-linux-aarch64/bin"
```
* compile process:
```
[root@ecs-2bfc ~]# git clone https://github.com/chenshuo/muduo
Cloning into 'muduo'...
remote: Enumerating objects: 8424, done.
remote: Counting objects: 100% (250/250), done.
remote: Compressing objects: 100% (48/48), done.
remote: Total 8424 (delta 214), reused 202 (delta 202), pack-reused 8174
Receiving objects: 100% (8424/8424), 1.76 MiB | 3.32 MiB/s, done.
Resolving deltas: 100% (5244/5244), done.
[root@ecs-2bfc ~]# cd muduo
[root@ecs-2bfc muduo]# git checkout cpp17
Branch 'cpp17' set up to track remote branch 'cpp17' from 'origin'.
Switched to a new branch 'cpp17'
[root@ecs-2bfc muduo]# ./build.sh 
++ pwd
+ SOURCE_DIR=/root/muduo
+ BUILD_DIR=../build
+ BUILD_TYPE=release
+ INSTALL_DIR=../release-install-cpp17
+ CXX=g++
+ ln -sf ../build/release-cpp17/compile_commands.json
+ mkdir -p ../build/release-cpp17
+ cd ../build/release-cpp17
+ cmake -DCMAKE_BUILD_TYPE=release -DCMAKE_INSTALL_PREFIX=../release-install-cpp17 -DCMAKE_EXPORT_COMPILE_COMMANDS=ON /root/muduo
CMake Deprecation Warning at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 2.8.12 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.


-- Could NOT find Boost (missing: Boost_INCLUDE_DIR) 
-- Could NOT find Protobuf (missing: Protobuf_LIBRARIES Protobuf_INCLUDE_DIR) 
-- Could NOT find CURL (missing: CURL_LIBRARY CURL_INCLUDE_DIR) 
-- Could NOT find ZLIB (missing: ZLIB_LIBRARY ZLIB_INCLUDE_DIR) 
-- CXX_FLAGS = -g -DCHECK_PTHREAD_RETURN_VALUE -D_FILE_OFFSET_BITS=64 -Wall -Wextra -Werror -Wconversion -Wno-unused-parameter -Wold-style-cast -Woverloaded-virtual -Wpointer-arith -Wshadow -Wwrite-strings -march=native -std=c++17 -rdynamic -O2 -DNDEBUG
-- Configuring done
-- Generating done
-- Build files have been written to: /root/build/release-cpp17
+ make
[  0%] Building CXX object muduo/base/CMakeFiles/muduo_base.dir/AsyncLogging.cc.o
[  0%] Building CXX object muduo/base/CMakeFiles/muduo_base.dir/Condition.cc.o
[  1%] Building CXX object muduo/base/CMakeFiles/muduo_base.dir/CountDownLatch.cc.o
[  1%] Building CXX object muduo/base/CMakeFiles/muduo_base.dir/CurrentThread.cc.o
[  1%] Building CXX object muduo/base/CMakeFiles/muduo_base.dir/Date.cc.o
[  1%] Building CXX object muduo/base/CMakeFiles/muduo_base.dir/Exception.cc.o
[  2%] Building CXX object muduo/base/CMakeFiles/muduo_base.dir/FileUtil.cc.o
[  2%] Building CXX object muduo/base/CMakeFiles/muduo_base.dir/LogFile.cc.o
[  2%] Building CXX object muduo/base/CMakeFiles/muduo_base.dir/Logging.cc.o
[  3%] Building CXX object muduo/base/CMakeFiles/muduo_base.dir/LogStream.cc.o
/root/muduo/muduo/base/LogStream.cc: In member function ‘void muduo::LogStream::staticCheck()’:
/root/muduo/muduo/base/LogStream.cc:107:3: error: static assertion failed: kMaxNumericSize is large enough
   static_assert(kMaxNumericSize - 10 > std::numeric_limits<long double>::digits10,
   ^~~~~~~~~~~~~
make[2]: *** [muduo/base/CMakeFiles/muduo_base.dir/build.make:202: muduo/base/CMakeFiles/muduo_base.dir/LogStream.cc.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:1057: muduo/base/CMakeFiles/muduo_base.dir/all] Error 2
make: *** [Makefile:146: all] Error 2
[root@ecs-2bfc muduo]# 
```