### PR TITLE
Fix multiple simultaneous requests to same URL cause coredump

### DIFF
--- a/examples/curl/Curl.cc
+++ b/examples/curl/Curl.cc
@@ -161,6 +161,7 @@ int Curl::socketCallback(CURL* c, int fd, int what, void* userp, void* socketp)
     muduo::net::Channel* ch = static_cast<Channel*>(socketp);
     if (!ch)
     {
+      if (req->getChannel()) return 0;
       ch = req->setChannel(fd);
       ch->setReadCallback(std::bind(&Curl::onRead, curl, fd));
       ch->setWriteCallback(std::bind(&Curl::onWrite, curl, fd));


### PR DESCRIPTION
**1. BUILD_TYPE=debug**

examples/curl/mcurl.cc:

```
  curl::RequestPtr req = curl.getUrl("https://chenshuo.com");
  req->setDataCallback(onData);
  req->setDoneCallback(done);

  curl::RequestPtr req2 = curl.getUrl("https://chenshuo.com");
  // req2->allowRedirect(5);
  req2->setDataCallback(onData);
  req2->setDoneCallback(done);

  curl::RequestPtr req3 = curl.getUrl("https://chenshuo.com");
  // req3->allowRedirect(5);
  req3->setDataCallback(onData);
  req3->setDoneCallback(done);
```

Error output:

> mcurl: /home/williammuji/codebase/muduo/examples/curl/Curl.cc:81: muduo::net::Channel* curl::Request::setChannel(int): Assertion `channel_.get() == NULL' failed.

**2. BUILD_TYPE=release**

coredump