### PR TITLE
fix missing header of noncopyable.h and coredump issue

### DIFF
--- a/contrib/hiredis/Hiredis.h
+++ b/contrib/hiredis/Hiredis.h
@@ -1,6 +1,7 @@
 #ifndef MUDUO_CONTRIB_HIREDIS_HIREDIS_H
 #define MUDUO_CONTRIB_HIREDIS_HIREDIS_H
 
+#include <muduo/base/noncopyable.h>
 #include <muduo/base/StringPiece.h>
 #include <muduo/base/Types.h>
 #include <muduo/net/Callbacks.h>

--- a/muduo/base/tests/BlockingQueue_bench.cc
+++ b/muduo/base/tests/BlockingQueue_bench.cc
@@ -13,9 +13,9 @@ class Bench
 {
  public:
   Bench(int numThreads)
-    : latch_(numThreads),
-      threads_(numThreads)
+    : latch_(numThreads)
   {
+    threads_.reserve(numThreads);
     for (int i = 0; i < numThreads; ++i)
     {
       char name[32];

--- a/muduo/base/tests/BoundedBlockingQueue_test.cc
+++ b/muduo/base/tests/BoundedBlockingQueue_test.cc
@@ -13,9 +13,9 @@ class Test
  public:
   Test(int numThreads)
     : queue_(20),
-      latch_(numThreads),
-      threads_(numThreads)
+      latch_(numThreads)
   {
+    threads_.reserve(numThreads);
     for (int i = 0; i < numThreads; ++i)
     {
       char name[32];


### PR DESCRIPTION
There is a coredump issue of binary **boundedblockingqueue_test**.
Also a header missing issue in hiredis module.

After patching, the binary can run normally.

 /workspaces/codespaces-blank/muduo (dev) $ ../build/release-cpp17/bin/boundedblockingqueue_test
pid=76040, tid=76040
tid=76041, work thread 0 started
tid=76042, work thread 1 started
tid=76043, work thread 2 started
tid=76044, work thread 3 started
tid=76045, work thread 4 started
waiting for count down latch
all threads started
tid=76040, put data = hello 0, size = 1
tid=76040, put data = hello 1, size = 2
tid=76043, get data = hello 1, size = 1
tid=76040, put data = hello 2, size = 0
tid=76040, put data = hello 3, size = 1
tid=76040, put data = hello 4, size = 2
tid=76040, put data = hello 5, size = 2
tid=76040, put data = hello 6, size = 3
tid=76040, put data = hello 7, size = 4
tid=76040, put data = hello 8, size = 5
tid=76040, put data = hello 9, size = 6
tid=76040, put data = hello 10, size = 7
tid=76040, put data = hello 11, size = 8
tid=76040, put data = hello 12, size = 9
tid=76040, put data = hello 13, size = 10
tid=76040, put data = hello 14, size = 11
tid=76040, put data = hello 15, size = 12
tid=76040, put data = hello 16, size = 13
tid=76040, put data = hello 17, size = 14
tid=76040, put data = hello 18, size = 15
tid=76040, put data = hello 19, size = 16
tid=76040, put data = hello 20, size = 17
tid=76040, put data = hello 21, size = 18
tid=76040, put data = hello 22, size = 19
tid=76040, put data = hello 23, size = 20
......
......
tid=76041, get data = hello 98, size = 6
tid=76041, get data = hello 99, size = 5
tid=76041, get data = stop, size = 4
tid=76041, work thread 0 stopped
tid=76044, get data = hello 82, size = 16
tid=76044, get data = stop, size = 3
tid=76044, work thread 3 stopped
tid=76042, get data = hello 88, size = 11
tid=76042, get data = stop, size = 2
tid=76042, work thread 1 stopped
tid=76043, get data = stop, size = 1
tid=76043, work thread 2 stopped
tid=76045, get data = hello 89, size = 15
tid=76045, get data = stop, size = 0
tid=76045, work thread 4 stopped
number of created threads 5
 /workspaces/codespaces-blank/muduo (dev) $ echo $?
0