### PR TITLE
use git action for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI for master branch PR
+
+on:
+  # Triggers the workflow on push or pull request events but only for the main branch
+  pull_request:
+    branches: [ master ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      - name: Show version of tools
+        run: |
+          gcc -v
+          g++ -v
+          make -v
+          cmake --version
+    
+      - name: Cache apt packages
+        uses: actions/cache@v3
+        with:
+          path: /var/cache/apt/archives/*.deb
+          key: ${{ runner.os }}-apt-${{ hashFiles('apt-packages.txt') }}
+
+      - name: Install dependencies
+        run: |
+          - sudo apt-get install libboost-dev
+          - sudo apt-get install libprotobuf-dev protobuf-compiler libprotoc-dev libgoogle-perftools-dev
+          - sudo apt-get install libboost-test-dev libboost-program-options-dev libboost-system-dev
+          - sudo apt-get install libc-ares-dev libcurl4-openssl-dev
+          - sudo apt-get install zlib1g-dev libgd-dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          - sudo apt-get install libboost-dev
-          - sudo apt-get install libprotobuf-dev protobuf-compiler libprotoc-dev libgoogle-perftools-dev
-          - sudo apt-get install libboost-test-dev libboost-program-options-dev libboost-system-dev
-          - sudo apt-get install libc-ares-dev libcurl4-openssl-dev
-          - sudo apt-get install zlib1g-dev libgd-dev
+          sudo apt-get install libboost-dev
+          sudo apt-get install libprotobuf-dev protobuf-compiler libprotoc-dev libgoogle-perftools-dev
+          sudo apt-get install libboost-test-dev libboost-program-options-dev libboost-system-dev
+          sudo apt-get install libc-ares-dev libcurl4-openssl-dev
+          sudo apt-get install zlib1g-dev libgd-dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,3 +40,12 @@ jobs:
           sudo apt-get install libboost-test-dev libboost-program-options-dev libboost-system-dev
           sudo apt-get install libc-ares-dev libcurl4-openssl-dev
           sudo apt-get install zlib1g-dev libgd-dev
+
+      - name: Set up environment variables
+        run: |
+          echo "BUILD_TYPE=debug" >> $GITHUB_ENV
+          echo "BUILD_TYPE=release" >> $GITHUB_ENV
+
+      - name: Build project
+        run: |
+          ./build.sh


### PR DESCRIPTION
Though travis CI is still available in Github but officially git actions is preferred.

When a PR or Forked PR is created or updated this git action will be triggered.

For non-contributor or non-member of repo, you can **limit** the running of CI by repo setting

**(setting tab -> Actions -> General -> Approval for running fork pull request workflows from contributors -> toggle 
Require approval for all external contributors).**

<img width="1286" height="285" alt="image" src="https://github.com/user-attachments/assets/074f5a0a-2ff2-4611-b4cc-675aa46115b7" />

